### PR TITLE
generalize function definitions to support cuda

### DIFF
--- a/src/arnoldi.jl
+++ b/src/arnoldi.jl
@@ -40,10 +40,9 @@ end
 
 KrylovSubspace{T}(args...) where {T} = KrylovSubspace{T,T}(args...)
 
-
 getV(Ks::KrylovSubspace) = @view(Ks.V[:, 1:Ks.m + 1])
 getH(Ks::KrylovSubspace) = @view(Ks.H[1:Ks.m + 1, 1:Ks.m+!iszero(Ks.augmented)])
-function Base.resize!(Ks::KrylovSubspace{B,T,U}, maxiter::Integer) where {B,T,U}
+function Base.resize!(Ks::KrylovSubspace{T,U,B}, maxiter::Integer) where {B,T,U}
     isaugmented = !iszero(Ks.augmented)
     V = Matrix{T}(undef, size(Ks.V, 1), maxiter + 1)
     H = fill(zero(U), maxiter + 1, maxiter + isaugmented)
@@ -204,7 +203,7 @@ end
 
 Non-allocating version of `arnoldi`.
 """
-function arnoldi!(Ks::KrylovSubspace{B, T1, U}, A::AT, b;
+function arnoldi!(Ks::KrylovSubspace{T1, U, B}, A::AT, b;
                   tol::Real=1e-7, m::Int=min(Ks.maxiter, size(A, 1)),
                   ishermitian::Bool=LinearAlgebra.ishermitian(A isa Tuple ? first(A) : A),
                   opnorm=nothing, iop::Int=0,
@@ -277,7 +276,7 @@ realview(::Type{R}, V::AbstractVector{R}) where {R} = V
 A variation of `arnoldi!` that uses the Lanczos algorithm for
 Hermitian matrices.
 """
-function lanczos!(Ks::KrylovSubspace{B, T1, U}, A::AT, b;
+function lanczos!(Ks::KrylovSubspace{T1, U, B}, A::AT, b;
                   tol=1e-7, m=min(Ks.maxiter, size(A, 1)),
                   opnorm=nothing,
                   init::Int=0, t::Number=NaN, mu::Number=NaN, l::Int=-1) where {B, T1 <: Number, U <: Number, AT}

--- a/src/arnoldi.jl
+++ b/src/arnoldi.jl
@@ -44,8 +44,9 @@ getV(Ks::KrylovSubspace) = @view(Ks.V[:, 1:Ks.m + 1])
 getH(Ks::KrylovSubspace) = @view(Ks.H[1:Ks.m + 1, 1:Ks.m+!iszero(Ks.augmented)])
 function Base.resize!(Ks::KrylovSubspace{T,U}, maxiter::Integer) where {T,U}
     isaugmented = !iszero(Ks.augmented)
-    V = Matrix{T}(undef, size(Ks.V, 1), maxiter + 1)
-    H = fill(zero(U), maxiter + 1, maxiter + isaugmented)
+    V = similar(Ks.V, T, (size(Ks.V, 1), maxiter + 1))
+    H = similar(Ks.H, U, (maxiter + 1, maxiter + isaugmented))
+    fill!(H, zero(U))
     if isaugmented
       copyto!(@view(V[axes(Ks.V)...]), Ks.V)
       copyto!(@view(H[axes(Ks.H)...]), Ks.H)
@@ -97,19 +98,33 @@ Springer, Cham.
 function arnoldi(A, b; m=min(30, size(A, 1)), ishermitian=LinearAlgebra.ishermitian(A), kwargs...)
     TA, Tb = eltype(A), eltype(b)
     T = promote_type(TA, Tb)
-    Ks = KrylovSubspace{T, ishermitian ? real(T) : T}(length(b), m)
+    n = length(b)
+    U = ishermitian ? real(T) : T
+
+    V = similar(A, T, (n, m + 1))
+    H = similar(A, U, (m+1, m))
+    fill!(H, zero(U))
+
+    Ks = KrylovSubspace{T, U, real(T), typeof(V), typeof(H)}(m, m, false, zero(real(T)), V, H)
+
     arnoldi!(Ks, A, b; m=m, ishermitian=ishermitian, kwargs...)
 end
 
 ## Low-level interface
-
-@inline function applyA!(y, A::AT, x, V, j, n, p) where AT
+@inline function applyA!(y, A, x, V, j, n, p)
     # We cannot add `@inbounds` to `mul!`, because it is provided by the user.
-    AT <: Tuple #= augmented =# || (mul!(y, A, x); return)
+    mul!(y, A, x)
+    return
+end
+
+# augmented
+# split augmented V? so this runs on GPU
+@inline function applyA!(y, A::Tuple, x, V, j, n, p)
     A, B = A
     @inbounds begin
         # V[1:n, j + 1] = A * @view(V[1:n, j]) + B * @view(V[n+1:n+p, j])
         mul!(@view(V[1:n, j + 1]), A, @view(V[1:n, j]))
+
         BLAS.gemm!('N', 'N', 1.0, B, @view(V[n+1:n+p, j]), 1.0, @view(V[1:n, j + 1]))
         copyto!(@view(V[n+1:n+p-1, j + 1]), @view(V[n+2:n+p, j]))
         V[end, j + 1] = 0
@@ -156,11 +171,11 @@ Compute the first step of Arnoldi or Lanczos iteration of augmented system.
 function firststep!(Ks::KrylovSubspace, V, H, b, b_aug, t, mu, l)
     @inbounds begin
         n, p = length(b), length(b_aug)
-        for k=1:p-1
+        map!(b_aug, 1:p) do k
+            k == p && return mu
             i = p - k
-            b_aug[k] = t^i/factorial(i) * mu
+            return t^i/factorial(i) * mu
         end
-        b_aug[p] = mu
 
         # Initialize the matrices V and H
         fill!(H, 0)
@@ -189,6 +204,11 @@ function arnoldi_step!(j::Integer, iop::Integer, A::AT,
                        n::Int=-1, p::Int=-1) where {AT,T,U}
     x, y = @view(V[:, j]), @view(V[:, j+1])
     applyA!(y, A, x, V, j, n, p)
+
+    # NOTE: H should always be Array
+    # on CUDA, we prefer to perform dot
+    # using CUBLAS and store the result in Array
+    # since the size of H is rather small
     @inbounds for i = max(1, j - iop + 1):j
         α = H[i, j] = coeff(U, dot(@view(V[:, i]), y))
         axpy!(-α, @view(V[:, i]), y)
@@ -276,10 +296,10 @@ realview(::Type{R}, V::AbstractVector{R}) where {R} = V
 A variation of `arnoldi!` that uses the Lanczos algorithm for
 Hermitian matrices.
 """
-function lanczos!(Ks::KrylovSubspace{T1, U}, A::AT, b;
+function lanczos!(Ks::KrylovSubspace{T1, U, B}, A::AT, b;
                   tol=1e-7, m=min(Ks.maxiter, size(A, 1)),
                   opnorm=nothing,
-                  init::Int=0, t::Number=NaN, mu::Number=NaN, l::Int=-1) where {T1 <: Number, U <: Number, AT}
+                  init::Int=0, t::Number=NaN, mu::Number=NaN, l::Int=-1) where {T1 <: Number, U <: Number, B, AT}
     m > Ks.maxiter ? resize!(Ks, m) : Ks.m = m # might change if happy-breakdown occurs
     @inbounds V, H = getV(Ks), getH(Ks)
     b′, b_aug, n, p = checkdims(A, b, V)

--- a/src/arnoldi.jl
+++ b/src/arnoldi.jl
@@ -42,7 +42,7 @@ KrylovSubspace{T}(args...) where {T} = KrylovSubspace{T,T}(args...)
 
 getV(Ks::KrylovSubspace) = @view(Ks.V[:, 1:Ks.m + 1])
 getH(Ks::KrylovSubspace) = @view(Ks.H[1:Ks.m + 1, 1:Ks.m+!iszero(Ks.augmented)])
-function Base.resize!(Ks::KrylovSubspace{T,U,B}, maxiter::Integer) where {B,T,U}
+function Base.resize!(Ks::KrylovSubspace{T,U}, maxiter::Integer) where {T,U}
     isaugmented = !iszero(Ks.augmented)
     V = Matrix{T}(undef, size(Ks.V, 1), maxiter + 1)
     H = fill(zero(U), maxiter + 1, maxiter + isaugmented)
@@ -203,11 +203,11 @@ end
 
 Non-allocating version of `arnoldi`.
 """
-function arnoldi!(Ks::KrylovSubspace{T1, U, B}, A::AT, b;
+function arnoldi!(Ks::KrylovSubspace{T1, U}, A::AT, b;
                   tol::Real=1e-7, m::Int=min(Ks.maxiter, size(A, 1)),
                   ishermitian::Bool=LinearAlgebra.ishermitian(A isa Tuple ? first(A) : A),
                   opnorm=nothing, iop::Int=0,
-                  init::Int=0, t::Number=NaN, mu::Number=NaN, l::Int=-1) where {B, T1 <: Number, U <: Number, AT}
+                  init::Int=0, t::Number=NaN, mu::Number=NaN, l::Int=-1) where {T1 <: Number, U <: Number, AT}
     ishermitian && return lanczos!(Ks, A, b; tol=tol, m=m, init=init, t=t, mu=mu, l=l)
     m > Ks.maxiter ? resize!(Ks, m) : Ks.m = m # might change if happy-breakdown occurs
     @inbounds V, H = getV(Ks), getH(Ks)
@@ -276,10 +276,10 @@ realview(::Type{R}, V::AbstractVector{R}) where {R} = V
 A variation of `arnoldi!` that uses the Lanczos algorithm for
 Hermitian matrices.
 """
-function lanczos!(Ks::KrylovSubspace{T1, U, B}, A::AT, b;
+function lanczos!(Ks::KrylovSubspace{T1, U}, A::AT, b;
                   tol=1e-7, m=min(Ks.maxiter, size(A, 1)),
                   opnorm=nothing,
-                  init::Int=0, t::Number=NaN, mu::Number=NaN, l::Int=-1) where {B, T1 <: Number, U <: Number, AT}
+                  init::Int=0, t::Number=NaN, mu::Number=NaN, l::Int=-1) where {T1 <: Number, U <: Number, AT}
     m > Ks.maxiter ? resize!(Ks, m) : Ks.m = m # might change if happy-breakdown occurs
     @inbounds V, H = getV(Ks), getH(Ks)
     b′, b_aug, n, p = checkdims(A, b, V)

--- a/src/krylov_phiv.jl
+++ b/src/krylov_phiv.jl
@@ -58,7 +58,7 @@ function _expv_ee(t::Tt, A, b; m=min(30, size(A, 1)), tol=1e-7, rtol=√(tol),
     w = similar(b, promote_type(Tt, eltype(A), eltype(b)))
     expv!(w, t, A, b, Ks, get_subspace_cache(Ks); atol=tol, rtol=rtol)
 end
-function expv(t::Tt, Ks::KrylovSubspace{B, T, U}; kwargs...) where {Tt, B, T, U}
+function expv(t::Tt, Ks::KrylovSubspace{T, U}; kwargs...) where {Tt, T, U}
     n = size(getV(Ks), 1)
     w = Vector{promote_type(Tt, T)}(undef, n)
     expv!(w, t, Ks; kwargs...)
@@ -68,8 +68,8 @@ end
 
 Non-allocating version of `expv` that uses precomputed Krylov subspace `Ks`.
 """
-function expv!(w::AbstractVector{Tw}, t::Real, Ks::KrylovSubspace{B, T, U};
-               cache=nothing) where {Tw, B, T, U}
+function expv!(w::AbstractVector{Tw}, t::Real, Ks::KrylovSubspace{T, U};
+               cache=nothing) where {Tw, T, U}
     m, beta, V, H = Ks.m, Ks.beta, getV(Ks), getH(Ks)
     @assert length(w) == size(V, 1) "Dimension mismatch"
     if cache == nothing
@@ -95,8 +95,8 @@ end
 # NOTE: Tw can be Float64, while t is ComplexF64 and T is Float32
 #       or Tw can be Float64, while t is ComplexF32 and T is Float64
 #       thus they can not share the same TypeVar.
-function expv!(w::AbstractVector{Complex{Tw}}, t::Complex{Tt}, Ks::KrylovSubspace{B, T, U};
-                cache=nothing) where {Tw, Tt, B, T, U}
+function expv!(w::AbstractVector{Complex{Tw}}, t::Complex{Tt}, Ks::KrylovSubspace{T, U};
+                cache=nothing) where {Tw, Tt, T, U}
     m, beta, V, H = Ks.m, Ks.beta, getV(Ks), getH(Ks)
     @assert length(w) == size(V, 1) "Dimension mismatch"
     if cache == nothing
@@ -175,7 +175,7 @@ function phiv(t, A, b, k; cache=nothing, correct=false, errest=false, kwargs_arn
     w = Matrix{eltype(b)}(undef, length(b), k+1)
     phiv!(w, t, Ks, k; cache=cache, correct=correct, errest=errest)
 end
-function phiv(t, Ks::KrylovSubspace{B, T, U}, k; kwargs...) where {B, T, U}
+function phiv(t, Ks::KrylovSubspace{T, U}, k; kwargs...) where {T, U}
     n = size(getV(Ks), 1)
     w = Matrix{T}(undef, n, k+1)
     phiv!(w, t, Ks, k; kwargs...)
@@ -185,8 +185,8 @@ end
 
 Non-allocating version of 'phiv' that uses precomputed Krylov subspace `Ks`.
 """
-function phiv!(w::AbstractMatrix{T}, t::Number, Ks::KrylovSubspace{B, T, U}, k::Integer;
-               cache=nothing, correct=false, errest=false) where {B, T <: Number, U <: Number}
+function phiv!(w::AbstractMatrix{T}, t::Number, Ks::KrylovSubspace{T, U}, k::Integer;
+               cache=nothing, correct=false, errest=false) where {T <: Number, U <: Number}
     m, beta, V, H = Ks.m, Ks.beta, getV(Ks), getH(Ks)
     @assert size(w, 1) == size(V, 1) "Dimension mismatch"
     @assert size(w, 2) == k + 1 "Dimension mismatch"

--- a/src/krylov_phiv_error_estimate.jl
+++ b/src/krylov_phiv_error_estimate.jl
@@ -33,9 +33,9 @@ function expT!(α::AbstractVector{R}, β::AbstractVector{R}, t::Number,
     mul!(@view(cache.v[sel]), @view(cache.sw.Z[sel,sel]), @view(cache.w[sel]))
 end
 
-get_subspace_cache(Ks::KrylovSubspace{B,T,U}) where {B,T,U<:Complex} =
+get_subspace_cache(Ks::KrylovSubspace{T,U}) where {T,U<:Complex} =
     error("Subspace exponential caches not yet available for non-Hermitian matrices.")
-get_subspace_cache(Ks::KrylovSubspace{B,T,U}) where {B,T,U<:Real} =
+get_subspace_cache(Ks::KrylovSubspace{T,U}) where {T,U<:Real} =
     StegrCache(T, Ks.maxiter)
 
 ########################################
@@ -52,7 +52,7 @@ exact type decides which algorithm is used to compute the subspace
 exponential.
 """
 function expv!(w::AbstractVector{T}, t::Number, A, b::AbstractVector{T},
-               Ks::KrylovSubspace{B, T, B}, cache::HSC;
+               Ks::KrylovSubspace{T, B, B}, cache::HSC;
                atol::B=1.0e-8, rtol::B=1.0e-4,
                m=min(Ks.maxiter, size(A,1)),
                verbose::Bool=false) where {B, T <: Number, HSC <: HermitianSubspaceCache}


### PR DESCRIPTION
I generalized some definitions to support CUDA, which closes #27 . but to make `expv!` work on CUDA, one needs this patch: 

https://github.com/JuliaGPU/CUDA.jl/pull/217

and this function

```jl
function ExponentialUtilities.expv!(w::CuVector{Tw}, t::Real, Ks::KrylovSubspace{T, U};
               cache=nothing, dexpHe::CuVector = CuVector{U}(undef, Ks.m)) where {Tw, T, U}
    m, beta, V, H = Ks.m, Ks.beta, getV(Ks), getH(Ks)
    @assert length(w) == size(V, 1) "Dimension mismatch"
    if cache == nothing
        cache = Matrix{U}(undef, m, m)
    elseif isa(cache, ExpvCache)
        cache = get_cache(cache, m)
    else
        throw(ArgumentError("Cache must be an ExpvCache"))
    end
    copyto!(cache, @view(H[1:m, :]))
    if ishermitian(cache)
        # Optimize the case for symtridiagonal H
        F = eigen!(SymTridiagonal(cache))
        expHe = F.vectors * (exp.(lmul!(t,F.values)) .* @view(F.vectors[1, :]))
    else
        lmul!(t, cache); expH = cache
        _exp!(expH)
        expHe = @view(expH[:, 1])
    end

    copyto!(dexpHe, expHe)
    lmul!(beta, mul!(w, @view(V[:, 1:m]), dexpHe)) # exp(A) ≈ norm(b) * V * exp(H)e
end
```

since this package is quite light-weight, I suppose it'd be better to have a separate package to support CUDA (so you don't have to download the entire CUDA when installing this for just CPU).

to give whoever interested in this a feeling about the acceleration, on our AWS machine with Tesla M60 GPU, I tested with A of size 10_000 x 10_000, b of size 10_000, t= 1e-2, for different method and arrays, this gives the following acceleration

Dense: 4.46x faster
Dense Hermitian: 2.75x faster
sparse(A), dense(b): 14.17x faster
sparse(A), dense(b) (Hermitian): 3.27x faster

Tho, it seems strange to me that Hermitian has lower acceleration rate (and is slower than the non-hermitian method), but this should give a speedup in general for many applications. I'll investigate this later maybe.

For folks interested in the implementation of CUDA, could refer to this gist for now: https://gist.github.com/Roger-luo/e7704108157ddea579e140354c4ba6df
