### PR TITLE
Zero fixes

### DIFF
--- a/src/krylov_phiv.jl
+++ b/src/krylov_phiv.jl
@@ -106,6 +106,10 @@ function expv!(w::AbstractVector{Complex{Tw}}, t::Complex{Tt}, Ks::KrylovSubspac
     else
         throw(ArgumentError("Cache must be an ExpvCache"))
     end
+    if iszero(Ks.beta)
+        w .= false
+        return w
+    end
     copyto!(cache, @view(H[1:m, :]))
     if ishermitian(cache)
         # Optimize the case for symtridiagonal H

--- a/src/krylov_phiv.jl
+++ b/src/krylov_phiv.jl
@@ -109,7 +109,7 @@ function expv!(w::AbstractVector{Complex{Tw}}, t::Complex{Tt}, Ks::KrylovSubspac
     copyto!(cache, @view(H[1:m, :]))
     if ishermitian(cache)
         # Optimize the case for symtridiagonal H
-        F = eigen!(SymTridiagonal(cache))
+        F = eigen!(SymTridiagonal(real(cache)))
         expHe = F.vectors * (exp.(t * F.values) .* @view(F.vectors[1, :]))
     else
         expH = _exp!(t * cache)

--- a/src/krylov_phiv_error_estimate.jl
+++ b/src/krylov_phiv_error_estimate.jl
@@ -64,6 +64,11 @@ function expv!(w::AbstractVector{T}, t::Number, A, b::AbstractVector{T},
 
     V, H = getV(Ks), getH(Ks)
     Ks.beta = norm(b)
+    if iszero(Ks.beta)
+        Ks.m = 0
+        w .= false
+        return w
+    end
     @. V[:, 1] = b / Ks.beta
 
     ε = atol + rtol * Ks.beta

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -99,6 +99,12 @@ end
     Ks = arnoldi(A, b)
     @test Ks.m == 2
 
+    # Test Arnoldi with zero input
+    z = zeros(n)
+    Ksz = arnoldi(A, z)
+    wz = expv(t, A, z; m=m)
+    @test norm(wz) == 0.0
+
     # Arnoldi vs Lanczos
     A = Hermitian(randn(n, n))
     Aperm = A + 1e-10 * randn(n, n) # no longer Hermitian
@@ -107,6 +113,10 @@ end
     wkiops = kiops(t, A, b; m=m)[1]
     @test w ≈ wperm
     @test w ≈ wkiops
+
+    # Test Lanczos with zero input
+    wz = expv(t, A, z; m=m)
+    @test norm(wz) == 0.0
 end
 
 @testset "Complex Value" begin
@@ -189,6 +199,10 @@ end
     δw = norm(w-w′)
     @test δw < atol
     @test δw/abs(1e-16+norm(w)) < rtol
+
+    z = zeros(ComplexF64, n)
+    wz = expv(-im, dt*A, z, m=m, tol=atol, rtol=rtol, mode=:error_estimate)
+    @test norm(wz) == 0
 end
 
 struct MatrixFreeOperator{T} <: AbstractMatrix{T}


### PR DESCRIPTION
If the RHS is zero, terminate the Krylov iterations directly, before dividing by `β`, which would yield a subspace filled with `NaNs`. I did not add a test for the augmented version, because I don't know how it works.

I also added a `real()` around the cache for the Lanczos case, but I don't remember when this was necessary. I'll see if I can come up with a case.