### PR TITLE
Avoid throwing on Infs in exp_generic

### DIFF
--- a/src/exp.jl
+++ b/src/exp.jl
@@ -116,6 +116,12 @@ by Higham, Nicholas J. in 2005 for algorithm details.
 """
 function exp_generic(x, vk=Val{13}())
     nx = opnorm(x, 1)
+    if !isfinite(nx)
+        # This should (hopefully) ensure that the result is Inf or NaN depending on
+        # which values are produced by a power series. I.e. the result shouldn't
+        # be all Infs when there are both Infs and zero since Inf*0===NaN
+        return x*sum(x*nx)
+    end
     s = iszero(nx) ? 0 : ceil(Int, log2(nx))
     if s >= 1
         exp_generic(x/(2^s), vk)^(2^s)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,6 +28,14 @@ end
 
         exp(n) ≈ exp_generic(n)
     end
+
+    @testset "Inf" begin
+        @test exp_generic(Inf) == Inf
+        @test exp_generic(NaN) === NaN
+        @test all(isinf, exp_generic([1 Inf; Inf 1]))
+        @test all(isnan, exp_generic([1 Inf; Inf 0]))
+        @test all(isnan, exp_generic([1 Inf 1 0; 1 1 1 1; 1 1 1 1; 1 1 1 1]))
+    end
 end
 
 @testset "Issue 41" begin


### PR DESCRIPTION
This is useful when using the function inside an optimization where the step should simply be handled and thrown away.