### PR TITLE
Fix exp_generic for general AbstractMatrix.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -19,7 +19,8 @@ julia = "1"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["ForwardDiff", "Test", "SafeTestsets", "Random"]
+test = ["ForwardDiff", "Test", "SafeTestsets", "StaticArrays", "Random"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
 using Test, LinearAlgebra, Random, SparseArrays, ExponentialUtilities
 using ExponentialUtilities: getH, getV, _exp!
-using ForwardDiff
+using ForwardDiff, StaticArrays
 
 @testset "Exp" begin
     n = 100
@@ -83,7 +83,17 @@ end
         B = rand(n,n);
         C = similar(A);
         @test ExponentialUtilities.naivemul!(C, A, B, axes(C)...) ≈ A*B
+        if n ≤ 16
+            Am = MMatrix{n,n}(A)
+            Bm = MMatrix{n,n}(B)
+            Cm = MMatrix{n,n}(A)
+            @test ExponentialUtilities.naivemul!(Cm, Am, Bm, axes(Cm)...) ≈ A*B
+        end
     end
+    A = @SMatrix rand(7,7);
+    Am = MMatrix(A);
+    Aa = Matrix(A);
+    @test exp(Aa) ≈ exp_generic(Aa) ≈ exp_generic(Am) ≈ exp_generic(A)
 end
 
 @testset "Phi" begin


### PR DESCRIPTION
Fixing a couple oversights and adding tests to make sure `StaticArrays.MMatrix` still works, as an example generic mutable AbstractArray.

Those oversights were:
1. `Base.Experimental.Const` is only defined for `Array`.
2. `lu!` is only defined for `StridedMatrix`. `MMatrix` doesn't subtype strided, and also does not return `LinearAlgebra.LU`, returning `StaticArrays.LU` instead. The latter doesn't support `rdiv!`.

While it'd be nice to fix "2." in `StaticArrays`, for now it's easiest to just work around it here.