### PR TITLE
Unroll based off of sizeof(eltype(C))

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -82,12 +82,17 @@ end
         A = rand(n,n);
         B = rand(n,n);
         C = similar(A);
-        @test ExponentialUtilities.naivemul!(C, A, B, axes(C)...) ≈ A*B
+        AB = A*B;
+        @test ExponentialUtilities.naivemul!(C, A, B, axes(C,1), axes(C,2), Val(2), Val(1)) ≈ AB
+        @test ExponentialUtilities.naivemul!(C, A, B, axes(C,1), axes(C,2), Val(4), Val(2)) ≈ AB
+        @test ExponentialUtilities.naivemul!(C, A, B, axes(C,1), axes(C,2), Val(4), Val(3)) ≈ AB
         if n ≤ 16
             Am = MMatrix{n,n}(A)
             Bm = MMatrix{n,n}(B)
             Cm = MMatrix{n,n}(A)
-            @test ExponentialUtilities.naivemul!(Cm, Am, Bm, axes(Cm)...) ≈ A*B
+            @test ExponentialUtilities.naivemul!(Cm, Am, Bm, axes(Cm,1), axes(cm,2), Val(2), Val(2)) ≈ AB
+            @test ExponentialUtilities.naivemul!(Cm, Am, Bm, axes(Cm,1), axes(cm,2), Val(4), Val(2)) ≈ AB
+            @test ExponentialUtilities.naivemul!(Cm, Am, Bm, axes(Cm,1), axes(cm,2), Val(4), Val(3)) ≈ AB
         end
     end
     A = @SMatrix rand(7,7);

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -90,9 +90,9 @@ end
             Am = MMatrix{n,n}(A)
             Bm = MMatrix{n,n}(B)
             Cm = MMatrix{n,n}(A)
-            @test ExponentialUtilities.naivemul!(Cm, Am, Bm, axes(Cm,1), axes(cm,2), Val(2), Val(2)) ≈ AB
-            @test ExponentialUtilities.naivemul!(Cm, Am, Bm, axes(Cm,1), axes(cm,2), Val(4), Val(2)) ≈ AB
-            @test ExponentialUtilities.naivemul!(Cm, Am, Bm, axes(Cm,1), axes(cm,2), Val(4), Val(3)) ≈ AB
+            @test ExponentialUtilities.naivemul!(Cm, Am, Bm, axes(Cm,1), axes(Cm,2), Val(2), Val(2)) ≈ AB
+            @test ExponentialUtilities.naivemul!(Cm, Am, Bm, axes(Cm,1), axes(Cm,2), Val(4), Val(2)) ≈ AB
+            @test ExponentialUtilities.naivemul!(Cm, Am, Bm, axes(Cm,1), axes(Cm,2), Val(4), Val(3)) ≈ AB
         end
     end
     A = @SMatrix rand(7,7);


### PR DESCRIPTION
For huge duals, we probably don't want to unroll much at all.
For small duals, unrolling more helps.

The intention is to try and keep up with `SMatrix` performance, but while this does well in microbenchmarks, in practice it is still several times slower in the real workload, with 80% GC time vs 15% GC time for the SMatrix version. =/