### PR TITLE
Add cast to real for Gram-Schmidt coefficients

### DIFF
--- a/src/krylov_phiv.jl
+++ b/src/krylov_phiv.jl
@@ -82,7 +82,7 @@ function expv!(w::AbstractVector{Tw}, t::Real, Ks::KrylovSubspace{T, U};
     copyto!(cache, @view(H[1:m, :]))
     if ishermitian(cache)
         # Optimize the case for symtridiagonal H
-        F = eigen!(SymTridiagonal(cache))
+        F = eigen!(SymTridiagonal(real(cache)))
         expHe = F.vectors * (exp.(lmul!(t,F.values)) .* @view(F.vectors[1, :]))
     else
         lmul!(t, cache); expH = cache


### PR DESCRIPTION
According to this line, in the hermitian case, the actual coefficients are supposed to be real:
https://github.com/SciML/ExponentialUtilities.jl/blob/5460b95594a9e23f418710e568db3a92d7bcfd26/src/arnoldi.jl#L32
but the matrix type can be complex. `eigen!` is not implemented for complex-valued
symmetric tridiagonal matrices in LinearAlgebra, so this throws a method
error if the cache is complex hermitian.

This needs verification to ensure this is actually correct, but making this change makes the code work for my application at least.

Closes https://github.com/SciML/ExponentialUtilities.jl/issues/61