### PR TITLE
Avoid integer overflow when scaling the argument in the generic exp

### DIFF
--- a/src/exp_generic.jl
+++ b/src/exp_generic.jl
@@ -115,11 +115,11 @@ ExpMethodGeneric()=ExpMethodGeneric{Val(13)}();
 
 function exponential!(x,method::ExpMethodGeneric{Vk},cache=alloc_mem(x,method)) where Vk
     nx = opnorm(x, 1)
-    if !isfinite(nx)
+    if isnan(nx) || nx > 4611686018427387904 # i.e. 2^62 since it would cause overflow in 2^s
         # This should (hopefully) ensure that the result is Inf or NaN depending on
         # which values are produced by a power series. I.e. the result shouldn't
         # be all Infs when there are both Infs and zero since Inf*0===NaN
-        return x*sum(x*nx)
+        return x*sum(x*exp(nx))
     end
     s = iszero(nx) ? 0 : intlog2(nx)
     (Vk === Val{13}() && x isa AbstractMatrix && ismutable(x)) && return exp_generic_mutable(x, s, Val{13}())

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -91,6 +91,7 @@ exp_generic(A) = exponential!(copy(A),ExpMethodGeneric())
 
         @test exp_generic(Inf) == Inf
         @test exp_generic(NaN) === NaN
+        @test exp_generic(1e20) === Inf
         @test all(isinf, exp_generic([1 Inf; Inf 1]))
         @test all(isnan, exp_generic([1 Inf; Inf 0]))
         @test all(isnan, exp_generic([1 Inf 1 0; 1 1 1 1; 1 1 1 1; 1 1 1 1]))


### PR DESCRIPTION
See the added test for an example.