### PR TITLE
likely a typo in export

### DIFF
--- a/src/ExponentialUtilities.jl
+++ b/src/ExponentialUtilities.jl
@@ -28,7 +28,7 @@ include("krylov_phiv_error_estimate.jl")
 export phi, phi!, KrylovSubspace, arnoldi, arnoldi!, lanczos!, ExpvCache, PhivCache,
     expv, expv!, phiv, phiv!, kiops, expv_timestep, expv_timestep!, phiv_timestep, phiv_timestep!,
     StegrCache, get_subspace_cache, exponential!
-export ExpMethodHigham2005, ExpMethodHigham2005Base, ExpMethodHighamGeneric, ExpMethodNative, ExpMethodDiagonalization
+export ExpMethodHigham2005, ExpMethodHigham2005Base, ExpMethodGeneric, ExpMethodNative, ExpMethodDiagonalization
 function __init__()
     @require CuArrays="3a865a2d-5b23-5a0f-bc46-62713ec82fae" begin
         function ExponentialUtilities.expv!(w::CuArrays.CuVector{Tw},


### PR DESCRIPTION
The method `ExpMethodGeneric` was not exported, instead `ExpMethodHighamGeneric` got exported but in the package, the generic exp method struct is called `ExpMethodGeneric`

https://github.com/SciML/ExponentialUtilities.jl/blob/f34954f875d0c02ce04ea868601d381323c32a06/src/exp_generic.jl#L112-L114

`ExpMethodHighamGeneric` was only mentioned once in the export list:

https://github.com/SciML/ExponentialUtilities.jl/search?q=ExpMethodHighamGeneric

