### PR TITLE
update liblapack location to use libblastrampoline_jll if available

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,7 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+libblastrampoline_jll = "8e850b90-86db-534c-a0d3-1478176c7d93"
 
 [compat]
 ArrayInterface = "3, 4"

--- a/src/StegrWork.jl
+++ b/src/StegrWork.jl
@@ -3,7 +3,13 @@ using LinearAlgebra
 using LinearAlgebra.BLAS: @blasfunc
 using LinearAlgebra: BlasInt
 import LinearAlgebra.LAPACK: stegr!
-const liblapack = Base.liblapack_name
+
+if VERSION < v"1.7"
+    const liblapack = Base.liblapack_name
+else
+    using libblastrampoline_jll
+    const liblapack = libblastrampoline_jll.libblastrampoline
+end
 
 mutable struct StegrWork{T<:Real}
     jobz::Char


### PR DESCRIPTION
Closes #76.

Apparently `libblastrampoline_jll` works on 1.6??

cc @viralbshah