### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,7 @@ integrators in OrdinaryDiffEq. The package has no external dependencies, so it c
 ## Tutorials and Documentation
 
 For information on using the package,
-[see the stable documentation](https://exponentialutilities.sciml.ai/stable/). Use the
-[in-development documentation](https://exponentialutilities.sciml.ai/dev/) for the version of
-the documentation, which contains the unreleased features.
+[see the in-development documentation](https://exponentialutilities.sciml.ai/dev/).
 
 ## Example
 


### PR DESCRIPTION
The `/stable/` documentation link doesn't work, so instead point the readme to the `/dev/` documentation. This feels ridiculous as a PR, so someone can close it and make the change quickly