### PR TITLE
GPU support for expv and expv_timestep

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "1.19.0"
 
 [deps]
 ArrayInterfaceCore = "30b0a656-2188-435a-8636-2ec0e6a096e2"
+ArrayInterfaceGPUArrays = "6ba088a2-8465-4c0a-af30-387133b534db"
 GPUArraysCore = "46192b85-c4d5-4398-a991-12ede77f4527"
 GenericSchur = "c145ed77-6b09-5dd9-b285-bf645a82121e"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -14,8 +15,8 @@ libblastrampoline_jll = "8e850b90-86db-534c-a0d3-1478176c7d93"
 
 [compat]
 ArrayInterfaceCore = "0.1.1"
-GenericSchur = "0.5.3"
 GPUArraysCore = "0.1"
+GenericSchur = "0.5.3"
 julia = "1.6"
 
 [extras]

--- a/src/ExponentialUtilities.jl
+++ b/src/ExponentialUtilities.jl
@@ -1,6 +1,7 @@
 module ExponentialUtilities
 using LinearAlgebra, SparseArrays, Printf
-using ArrayInterfaceCore: ismutable
+using ArrayInterfaceCore: ismutable, allowed_getindex, allowed_setindex!
+using ArrayInterfaceGPUArrays
 import GenericSchur
 import GPUArraysCore
 

--- a/src/krylov_phiv.jl
+++ b/src/krylov_phiv.jl
@@ -148,11 +148,8 @@ function ExponentialUtilities.expv!(w::GPUArraysCore.AbstractGPUVector{Tw},
         F = eigen!(SymTridiagonal(cache))
         expHe = F.vectors * (exp.(lmul!(t, F.values)) .* @view(F.vectors[1, :]))
     else
-        # lmul!(t, cache)
-        # expH = cache
-        # _exp!(expH)
-        # expHe = @view(expH[:, 1])
-        expH = exponential!(t * cache, expmethod)
+        lmul!(t, cache)
+        expH = exponential!(cache, expmethod)
         expHe = @view(expH[:, 1])
     end
 
@@ -243,7 +240,7 @@ function phiv!(w::AbstractMatrix, t::Number, Ks::KrylovSubspace{T, U}, k::Intege
         throw(ArgumentError("Cache must be a PhivCache"))
     end
     e, Hcopy, C1, C2 = get_caches(cache, m, k)
-    lmul!(t, copyto!(Hcopy, H[1:m, :])) # For the moment copyto! doesn't work with views. lmul!(t, copyto!(Hcopy, @view(H[1:m, :])))
+    lmul!(t, copyto!(Hcopy, @view(H[1:m, :])))
     fill!(e, zero(T))
     allowed_setindex!(e, one(T), 1) # e is the [1,0,...,0] basis vector
     phiv_dense!(C2, Hcopy, e, k; cache = C1) # C2 = [ϕ0(H)e ϕ1(H)e ... ϕk(H)e]

--- a/src/krylov_phiv.jl
+++ b/src/krylov_phiv.jl
@@ -132,12 +132,7 @@ end
 function ExponentialUtilities.expv!(w::GPUArraysCore.AbstractGPUVector{Tw},
                                     t::Real, Ks::KrylovSubspace{T, U};
                                     cache = nothing,
-                                    dexpHe::GPUArraysCore.AbstractGPUVector = typeof(w)(undef,
-                                                                                        Ks.m)) where {
-                                                                                                      Tw,
-                                                                                                      T,
-                                                                                                      U
-                                                                                                      }
+                                    expmethod = ExpMethodHigham2005()) where {Tw, T, U}
     m, beta, V, H = Ks.m, Ks.beta, getV(Ks), getH(Ks)
     @assert length(w)==size(V, 1) "Dimension mismatch"
     if cache == nothing
@@ -153,14 +148,15 @@ function ExponentialUtilities.expv!(w::GPUArraysCore.AbstractGPUVector{Tw},
         F = eigen!(SymTridiagonal(cache))
         expHe = F.vectors * (exp.(lmul!(t, F.values)) .* @view(F.vectors[1, :]))
     else
-        lmul!(t, cache)
-        expH = cache
-        _exp!(expH)
+        # lmul!(t, cache)
+        # expH = cache
+        # _exp!(expH)
+        # expHe = @view(expH[:, 1])
+        expH = exponential!(t * cache, expmethod)
         expHe = @view(expH[:, 1])
     end
 
-    copyto!(dexpHe, expHe)
-    lmul!(beta, mul!(w, @view(V[:, 1:m]), dexpHe)) # exp(A) ≈ norm(b) * V * exp(H)e
+    lmul!(beta, mul!(w, @view(V[:, 1:m]), typeof(w)(expHe))) # exp(A) ≈ norm(b) * V * exp(H)e
 end
 
 compatible_multiplicative_operand(::AbstractArray, source::AbstractArray) = source
@@ -168,15 +164,15 @@ compatible_multiplicative_operand(::AbstractArray, source::AbstractArray) = sour
 ############################
 # Cache for phiv
 mutable struct PhivCache{T}
-    mem::Vector{T}
-    function PhivCache{T}(maxiter::Int, p::Int) where {T}
-        numelems = maxiter + maxiter^2 + (maxiter + p)^2 + maxiter * (p + 1)
-        new{T}(Vector{T}(undef, numelems))
-    end
+    mem::AbstractVector{T}
+end
+function PhivCache{T}(maxiter::Int, p::Int) where {T}
+    numelems = maxiter + maxiter^2 + (maxiter + p)^2 + maxiter * (p + 1)
+    PhivCache{T}(Vector{T}(undef, numelems))
 end
 function Base.resize!(C::PhivCache{T}, maxiter::Int, p::Int) where {T}
     numelems = maxiter + maxiter^2 + (maxiter + p)^2 + maxiter * (p + 1)
-    C.mem = Vector{T}(undef, numelems * 2)
+    C.mem = similar(C.mem, numelems * 2)
     return C
 end
 function get_caches(C::PhivCache, m::Int, p::Int)
@@ -235,7 +231,7 @@ end
 
 Non-allocating version of 'phiv' that uses precomputed Krylov subspace `Ks`.
 """
-function phiv!(w::AbstractMatrix{T}, t::Number, Ks::KrylovSubspace{T, U}, k::Integer;
+function phiv!(w::AbstractMatrix, t::Number, Ks::KrylovSubspace{T, U}, k::Integer;
                cache = nothing, correct = false,
                errest = false) where {T <: Number, U <: Number}
     m, beta, V, H = Ks.m, Ks.beta, getV(Ks), getH(Ks)
@@ -247,11 +243,11 @@ function phiv!(w::AbstractMatrix{T}, t::Number, Ks::KrylovSubspace{T, U}, k::Int
         throw(ArgumentError("Cache must be a PhivCache"))
     end
     e, Hcopy, C1, C2 = get_caches(cache, m, k)
-    lmul!(t, copyto!(Hcopy, @view(H[1:m, :])))
+    lmul!(t, copyto!(Hcopy, H[1:m, :])) # For the moment copyto! doesn't work with views. lmul!(t, copyto!(Hcopy, @view(H[1:m, :])))
     fill!(e, zero(T))
-    e[1] = one(T) # e is the [1,0,...,0] basis vector
+    allowed_setindex!(e, one(T), 1) # e is the [1,0,...,0] basis vector
     phiv_dense!(C2, Hcopy, e, k; cache = C1) # C2 = [ϕ0(H)e ϕ1(H)e ... ϕk(H)e]
-    lmul!(beta, mul!(w, @view(V[:, 1:m]), C2)) # f(A) ≈ norm(b) * V * f(H)e
+    lmul!(beta, mul!(w, @view(V[:, 1:m]), typeof(w)(C2))) # f(A) ≈ norm(b) * V * f(H)e
     if correct
         # Use the last Arnoldi vector for correction with little additional cost
         # correct_p = beta * h_{m+1,m} * (em^T phi_p+1(H) e1) * v_m+1

--- a/test/gpu/gputests.jl
+++ b/test/gpu/gputests.jl
@@ -1,5 +1,7 @@
-using CUDA: cu
 using LinearAlgebra
+using SparseArrays
+using CUDA
+using CUDA.CUSPARSE
 using ExponentialUtilities: inplace_add!, exponential!, ExpMethodHigham2005
 
 using Random: Xoshiro
@@ -29,4 +31,20 @@ end
             @test collect(eA_d) ≈ eA
         end
     end
+end
+
+@testset "GPU expv and expv_timestep" begin
+    n = 1000
+    A = sprand(ComplexF64, n, n, 10 / n)
+    A = triu(A, 1) + sprand(ComplexF64, n, n, 1 / n)
+    b = rand(ComplexF64, n)
+
+    A_gpu = CuSparseMatrixCSR(A)
+    b_gpu = CuArray(b)
+
+    t = 0.1
+    ts = Array(LinRange(0, 1, 300))
+
+    @test expv(t, A, b) ≈ Array(expv(t, A_gpu, b_gpu))
+    @test expv_timestep(ts, A, b) ≈ Array(expv_timestep(ts, A_gpu, b_gpu))
 end


### PR DESCRIPTION
Hello,

by changing only the syntax of several lines I implemented the GPU support for the `expv` and `expv_timestep` functions. The following code works now

```julia
using LinearAlgebra
using SparseArrays
using ExponentialUtilities
using BenchmarkTools
using CUDA
using CUDA.CUSPARSE
CUDA.allowscalar(false)
##
n = 70000
A = sprand(ComplexF64, n, n, 10 / n)
A = triu(A, 1) + sprand(ComplexF64, n, n, 1 / n)
b = rand(ComplexF64, n)

t = 0.1
ts = Array(LinRange(0, 1, 300))

expv(t, A, b)
@btime expv_timestep(ts, A, b)

A = CuSparseMatrixCSR(A)
b = CuArray(b)

expv(t, A, b)

@btime expv_timestep(ts, A, b)
```