### PR TITLE
vl/u type: Real to concrete to avoid runtime dispatch

### DIFF
--- a/src/StegrWork.jl
+++ b/src/StegrWork.jl
@@ -13,8 +13,8 @@ mutable struct StegrWork{T <: Real}
     range::Char
     dv::Vector{T}
     ev::Vector{T}
-    vl::Real
-    vu::Real
+    vl::T
+    vu::T
     il::BlasInt
     iu::BlasInt
     abstol::Vector{T}

--- a/test/basictests.jl
+++ b/test/basictests.jl
@@ -96,7 +96,9 @@ exp_generic(A) = exponential!(copy(A), ExpMethodGeneric())
     end
 end
 
-@testset "Issue 41" begin @test ForwardDiff.derivative(exp_generic, 0.1)≈exp_generic(0.1) atol=1e-15 end
+@testset "Issue 41" begin
+    @test ForwardDiff.derivative(exp_generic, 0.1)≈exp_generic(0.1) atol=1e-15
+end
 
 @testset "Issue 42" begin
     @test exp_generic(0.0) == 1


### PR DESCRIPTION
Currently, the vl/vu for the eigen value calculation for Hermitian case with error_estimation mode are `Real` type and can cause a runtime dispatch. Since they refer to the lower & upper limits to the eigen-values to calculate, it would make sense for them to just be the same type as the eltype of eigenvalues array `w`

https://github.com/SciML/ExponentialUtilities.jl/blob/0200288b7143535ae41580b342a54f31ea52279a/src/StegrWork.jl#L22

and they are converted as such in the ccalls as `Ref{elty}` with elty = Float32/64

https://github.com/SciML/ExponentialUtilities.jl/blob/0200288b7143535ae41580b342a54f31ea52279a/src/StegrWork.jl#L38

In addition, for the algorithm here, all eigenvalues are calculated (range='A' for all)
https://github.com/SciML/ExponentialUtilities.jl/blob/0200288b7143535ae41580b342a54f31ea52279a/src/StegrWork.jl#L74
and they are just set to 0.0
https://github.com/SciML/ExponentialUtilities.jl/blob/0200288b7143535ae41580b342a54f31ea52279a/src/StegrWork.jl#L91

(the ccall will ignore the upper/lower values vl/vu when range='A')

ccall ref: [here](https://netlib.org/lapack/explore-html/da/dba/group__double_o_t_h_e_rcomputational_gac5fa1f1c4eeb2f78df2ea644641392f6.html)

---
Run-time is more-or-less similar, the # of allocations is down
before:
> 503.167 μs (98 allocations: 282.28 KiB)

after:
> 497.875 μs (38 allocations: 281.34 KiB)

w/
```julia
using ExponentialUtilities, BenchmarkTools, Random

Random.seed!(1)
n = 512
h = Hermitian(randn(ComplexF64, n, n))
v = randn(ComplexF64, n)

@btime expv(0.1im, $h, $v, mode=:error_estimate);
```