### PR TITLE
Migrate from SnoopPrecompile to PrecompileTools

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ GPUArraysCore = "46192b85-c4d5-4398-a991-12ede77f4527"
 GenericSchur = "c145ed77-6b09-5dd9-b285-bf645a82121e"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
-SnoopPrecompile = "66db9d55-30c0-4569-8b51-7e840670fc0c"
+PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 libblastrampoline_jll = "8e850b90-86db-534c-a0d3-1478176c7d93"
 
@@ -19,7 +19,7 @@ Adapt = "3.4.0"
 ArrayInterface = "7"
 GPUArraysCore = "0.1"
 GenericSchur = "0.5.3"
-SnoopPrecompile = "1"
+PrecompileTools = "1"
 julia = "1.6"
 
 [extras]

--- a/src/ExponentialUtilities.jl
+++ b/src/ExponentialUtilities.jl
@@ -1,7 +1,7 @@
 module ExponentialUtilities
 using LinearAlgebra, SparseArrays, Printf
 using ArrayInterface: ismutable, allowed_getindex, allowed_setindex!
-using SnoopPrecompile
+using PrecompileTools
 import GenericSchur
 import GPUArraysCore
 import Adapt

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,4 +1,4 @@
-@precompile_setup begin
+@setup_workload begin
     function precomp_gen_mat(; Tx, n)
         mx = rand(Tx, n, n)
         m = rand(Tx, n, n)
@@ -42,6 +42,6 @@
     Txs = [Float64]
     #Txs = [Float64, ComplexF64]
 
-    @precompile_all_calls begin [precomp_fx(; method, Tx) for method in precomp_ms
+    @compile_workload begin [precomp_fx(; method, Tx) for method in precomp_ms
                                  for Tx in Txs] end
 end


### PR DESCRIPTION
This pull request migrates the package from [SnoopPrecompile](https://github.com/timholy/SnoopCompile.jl/tree/master/SnoopPrecompile) to [PrecompileTools](https://github.com/JuliaLang/PrecompileTools.jl).
PrecompileTools is **nearly a drop-in replacement** except that there are **changes in naming and how developers locally disable precompilation** (to make their development workflow more efficient). These changes are described in [PrecompileTool's enhanced documentation](https://julialang.github.io/PrecompileTools.jl/stable/), which also includes instructions for users on how to set up custom "Startup" packages, handling precompilation tasks that are not amenable to workloads, and tips for troubleshooting.

Why the new package? It meets several goals:

- The name "SnoopPrecompile" was easily confused with "SnoopCompile," a package designed for *analyzing* rather than *enacting* precompilation.
- SnoopPrecompile/PrecompileTools has become (directly or indirectly) a dependency for much of the Julia ecosystem, a trend that seems likely to grow with time. It makes sense to host it in a more central location than one developer's personal account.
- As Julia's own stdlibs migrate to become independently updateable (true for DelimitedFiles in Julia 1.9, with others anticipated for Julia 1.10), several of them would like to use PrecompileTools for high-quality precompilation. That requires making PrecompileTools its own "upgradable stdlib."
- We wanted to change the [use of Preferences](https://github.com/timholy/SnoopCompile.jl/issues/356) to make packages more independent of one another. Since this would have been a breaking change, it seemed like a good opportunity to fix other issues, too.

For more information and discussion, see this [discourse post](https://discourse.julialang.org/t/ann-snoopprecompile-precompiletools/97882).
