### PR TITLE
Allow for sparse matrices in exponential!?

### DIFF
--- a/src/exp_generic.jl
+++ b/src/exp_generic.jl
@@ -184,6 +184,7 @@ function exp_generic!(y1, y2, y3, x, s, ::Val{13})
 end
 # `lu!` is only defined for `StridedMatrix`, and `lu(::StaticArray)` (note `MArray<:StaticArray`) returns `::StaticArrays.LU !== LinearAlgebra.LU`
 _rdiv!(A, B::StridedMatrix) = rdiv!(A, lu!(B))
+_rdiv!(A, B::SparseMatrixCSC) = A / Array(B)
 _rdiv!(A, B) = A / B
 
 function exp_generic_core!(y1, y2, y3, x, ::Val{13})

--- a/test/basictests.jl
+++ b/test/basictests.jl
@@ -96,6 +96,11 @@ exp_generic(A) = exponential!(copy(A), ExpMethodGeneric())
     end
 end
 
+@testset "exponential! sparse" begin
+    A = sparse([1, 2, 1], [2, 1, 1], [1.0, 2.0, 3.0])
+    exponential!(copy(A), ExpMethodGeneric()) ≈ exp(Array(A))
+end
+
 @testset "Issue 41" begin
     @test ForwardDiff.derivative(exp_generic, 0.1)≈exp_generic(0.1) atol=1e-15
 end

--- a/test/basictests.jl
+++ b/test/basictests.jl
@@ -96,9 +96,11 @@ exp_generic(A) = exponential!(copy(A), ExpMethodGeneric())
     end
 end
 
-@testset "exponential! sparse" begin
-    A = sparse([1, 2, 1], [2, 1, 1], [1.0, 2.0, 3.0])
-    exponential!(copy(A), ExpMethodGeneric()) ≈ exp(Array(A))
+if VERSION >= v"1.9"
+    @testset "exponential! sparse" begin
+        A = sparse([1, 2, 1], [2, 1, 1], [1.0, 2.0, 3.0])
+        exponential!(copy(A), ExpMethodGeneric()) ≈ exp(Array(A))
+    end
 end
 
 @testset "Issue 41" begin


### PR DESCRIPTION
This would fix https://github.com/SciML/ExponentialUtilities.jl/issues/132, but the result is always dense so I'm not sure using a sparse matrix is actually a good idea because the result is dense. However, you do get some sparse LU so maybe it works out for somebody?
