### PR TITLE
Fix typo in expv_timestep documentation

### DIFF
--- a/src/krylov_phiv_adaptive.jl
+++ b/src/krylov_phiv_adaptive.jl
@@ -1,6 +1,6 @@
 # Krylov phiv with internal time-stepping
 """
-    exp_timestep(ts,A,b[;adaptive,tol,kwargs...]) -> U
+    expv_timestep(ts,A,b[;adaptive,tol,kwargs...]) -> U
 
 Evaluates the matrix exponentiation-vector product using time stepping
 


### PR DESCRIPTION
The documentation for the `expv_timestep` method contained a typo: `exp_timestep`.
