### PR TITLE
Finish timestepping after happy breakdown

### DIFF
--- a/src/arnoldi.jl
+++ b/src/arnoldi.jl
@@ -240,6 +240,9 @@ function arnoldi!(Ks::KrylovSubspace{T1, U}, A::AT, b;
     opnorm = nothing, iop::Int = 0,
     init::Int = 0, t::Number = NaN, mu::Number = NaN,
     l::Int = -1) where {T1 <: Number, U <: Number, AT}
+
+    Ks.wasbreakdown = false
+
     ishermitian &&
         return lanczos!(Ks, A, b; tol = tol, m = m, init = init, t = t, mu = mu, l = l)
     m > Ks.maxiter ? resize!(Ks, m) : Ks.m = m # might change if happy-breakdown occurs
@@ -317,6 +320,9 @@ function lanczos!(Ks::KrylovSubspace{T1, U, B}, A::AT, b;
     opnorm = nothing,
     init::Int = 0, t::Number = NaN, mu::Number = NaN,
     l::Int = -1) where {T1 <: Number, U <: Number, B, AT}
+
+    Ks.wasbreakdown = false
+
     m > Ks.maxiter ? resize!(Ks, m) : Ks.m = m # might change if happy-breakdown occurs
     @inbounds V, H = getV(Ks), getH(Ks)
     b′, b_aug, n, p = checkdims(A, b, V)

--- a/src/krylov_phiv_adaptive.jl
+++ b/src/krylov_phiv_adaptive.jl
@@ -73,6 +73,10 @@ Niesen & Wright is used, the relative tolerance of which can be set using the
 keyword parameter `tol`. The delta and gamma parameters of the adaptation
 scheme can also be adjusted.
 
+When encountering a happy breakdown in the Krylov subspace construction, the
+time step is set to the remainder of the time interval since time stepping is
+no longer necessary.
+
 Set `verbose=true` to print out the internal steps (for debugging). For the
 other keyword arguments, consult `arnoldi` and `phiv`, which are used
 internally.

--- a/src/krylov_phiv_adaptive.jl
+++ b/src/krylov_phiv_adaptive.jl
@@ -128,9 +128,9 @@ function phiv_timestep!(U::AbstractMatrix{T}, ts::Vector{tType}, A, B::AbstractM
         P = similar(B, T, n, p + 2)         # stores output from phiv!
         V_tmp = similar(B, T, n, m + 1)
         H_tmp = fill(zero(T), m + 1, m)
-        Ks = KrylovSubspace{T, T, real(T), typeof(V_tmp), Matrix{T}}(m, m, false,
-            zero(real(T)), V_tmp,
-            H_tmp) # stores output from arnoldi!. Here we support also GPUs
+        Ks = KrylovSubspace{T, T, real(T), typeof(V_tmp), Matrix{T}}(
+            m, m, false, zero(real(T)), false, V_tmp, H_tmp
+        ) # stores output from arnoldi!. Here we support also GPUs
         phiv_cache = nothing         # cache used by phiv!
     else
         u, W, P, Ks, phiv_cache = caches
@@ -157,6 +157,7 @@ function phiv_timestep!(U::AbstractMatrix{T}, ts::Vector{tType}, A, B::AbstractM
 
     t = 0.0       # current time
     snapshot = 1  # which snapshot to compute next
+    num_timesteps = 0
     while t < tend # time stepping loop
         if t + tau > tend # last step
             tau = tend - t
@@ -174,6 +175,9 @@ function phiv_timestep!(U::AbstractMatrix{T}, ts::Vector{tType}, A, B::AbstractM
         end
         # Part 2: compute ϕp(tau*A)wp using Krylov, possibly with adaptation
         arnoldi!(Ks, A, @view(W[:, end]); tol = tol, m = m, opnorm = opnorm, iop = iop)
+        if Ks.wasbreakdown
+            tau = tend - t
+        end
         _, epsilon = phiv!(P, tau, Ks, p + 1; cache = phiv_cache, correct = correct,
             errest = true)
         verbose && println("t = $t, m = $m, tau = $tau, error estimate = $epsilon")
@@ -230,7 +234,9 @@ function phiv_timestep!(U::AbstractMatrix{T}, ts::Vector{tType}, A, B::AbstractM
         end
 
         t += tau
+        num_timesteps += 1
     end
+    verbose && println("Completed after $num_timesteps time step(s)")
 
     return U
 end

--- a/test/basictests.jl
+++ b/test/basictests.jl
@@ -113,6 +113,18 @@ end
     @test ForwardDiff.derivative(t -> ForwardDiff.derivative(exp_generic, t), 0.0) == 1
 end
 
+@testset "Issue 143" begin
+    out = Pipe()
+    ts = collect(0:0.1:1)
+    res = redirect_stdout(out) do
+        expv_timestep(ts, [1.;;], [1.]; verbose = true)
+    end
+    close(Base.pipe_writer(out))
+
+    @test vec(res) ≈ exp.(ts)
+    @test occursin("Completed after 1 time step(s)", read(out, String))
+end
+
 @testset "naive_matmul" begin
     A = Matrix(reshape((1.0:(23.0^2)) ./ 700, (23, 23)))
     @test exp_generic(A) ≈ exp(A)

--- a/test/basictests.jl
+++ b/test/basictests.jl
@@ -114,15 +114,21 @@ end
 end
 
 @testset "Issue 143" begin
-    out = Pipe()
     ts = collect(0:0.1:1)
-    res = redirect_stdout(out) do
-        expv_timestep(ts, [1.;;], [1.]; verbose = true)
+
+    if VERSION >= v"1.7"
+        out = Pipe()
+        res = redirect_stdout(out) do
+            expv_timestep(ts, [1.;;], [1.]; verbose = true)
+        end
+        close(Base.pipe_writer(out))
+
+        @test occursin("Completed after 1 time step(s)", read(out, String))
+    else
+        res = expv_timestep(ts, [1.;;], [1.]; verbose = true)
     end
-    close(Base.pipe_writer(out))
 
     @test vec(res) ≈ exp.(ts)
-    @test occursin("Completed after 1 time step(s)", read(out, String))
 end
 
 @testset "naive_matmul" begin

--- a/test/basictests.jl
+++ b/test/basictests.jl
@@ -119,13 +119,13 @@ end
     if VERSION >= v"1.7"
         out = Pipe()
         res = redirect_stdout(out) do
-            expv_timestep(ts, [1.;;], [1.]; verbose = true)
+            expv_timestep(ts, reshape([1], (1, 1)), [1.]; verbose = true)
         end
         close(Base.pipe_writer(out))
 
         @test occursin("Completed after 1 time step(s)", read(out, String))
     else
-        res = expv_timestep(ts, [1.;;], [1.]; verbose = true)
+        res = expv_timestep(ts, reshape([1], (1, 1)), [1.]; verbose = true)
     end
 
     @test vec(res) ≈ exp.(ts)


### PR DESCRIPTION
Fixes #143 

I looked into that issue a bit more. Expokit.jl uses the same initial time step as ExponentialUtilities.jl, but does not face the dimension-1 issue since it stops timestepping upon a happy breakdown. When using the matrix dimension as the Krylov subspace dimension,  happy breakdown will occur and there is no need for taking (potentially very small) time steps.