### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,4 +7,4 @@ updates:
       interval: "weekly"
     ignore:
       - dependency-name: "crate-ci/typos"
-        update-types: ["version-update:semver-patch"]
+        update-types: ["version-update:semver-patch", "version-update:semver-minor"]


### PR DESCRIPTION
I think it should be configured like this to only work on major releases.
Won't know for sure until typos does a next minor release.