### PR TITLE
don't use generated function implimentation of naivemul for sparse matrices

### DIFF
--- a/src/exp_generic.jl
+++ b/src/exp_generic.jl
@@ -6,6 +6,10 @@ function naivemul!(C::StridedMatrix{T}, A::StridedMatrix{T},
         B::StridedMatrix{T}) where {T <: LinearAlgebra.BlasFloat}
     mul!(C, A, B)
 end
+function naivemul!(C::AbstractSparseMatrix, A::AbstractSparseMatrix,
+        B::AbstractSparseMatrix)
+    mul!(C, A, B)
+end
 function naivemul!(C, A, B)
     Maxis, Naxis = axes(C)
     # TODO: heuristically pick `Nunroll` and `Munroll` using `sizeof(T)`, and maybe based on size of register file as well.
@@ -136,7 +140,7 @@ function exponential!(x, method::ExpMethodGeneric{Vk},
     (Vk === Val{13}() && x isa AbstractMatrix && ismutable(x)) &&
         return exp_generic_mutable(x, s, Val{13}())
     if s >= 1
-        return exponential!(x / (2^s), method)^(2^s)
+        return exponential!(x / (2^s), method, cache)^(2^s)
     else
         return exp_pade_p(x, Vk, Vk) / exp_pade_q(x, Vk, Vk)
     end


### PR DESCRIPTION
I'm in general pretty skeptical of the `naivemul` introduced in https://github.com/SciML/ExponentialUtilities.jl/pull/57, but this at least makes it dramatically better for sparse matrices. This improves, but does not fix https://github.com/SciML/OrdinaryDiffEq.jl/issues/2121.

```
# before
julia> @time exponential!(sprand(500,500,.001), ExpMethodGeneric());
  9.914123 seconds (52 allocations: 13.983 MiB)

#after
@time exponential!(sprand(500,500,.001), ExpMethodGeneric());
  2.100566 seconds (260 allocations: 14.785 MiB)
```