### PR TITLE
Parametrize VType in KrylovSubspace constructor

### DIFF
--- a/src/arnoldi.jl
+++ b/src/arnoldi.jl
@@ -4,7 +4,7 @@
 # Output type/cache
 """
     KrylovSubspace{T}(n,[maxiter=30]) -> Ks
-    KrylovSubspace{T,U, VType}(n,[maxiter=30]) -> Ks
+    KrylovSubspace{T, U, VType}(n,[maxiter=30]) -> Ks
 
 Constructs an uninitialized Krylov subspace, which can be filled by `arnoldi!`.
 

--- a/src/arnoldi.jl
+++ b/src/arnoldi.jl
@@ -11,11 +11,15 @@ Constructs an uninitialized Krylov subspace, which can be filled by `arnoldi!`.
 The dimension of the subspace, `Ks.m`, can be dynamically altered but should
 be smaller than `maxiter`, the maximum allowed arnoldi iterations.
 
+The type of the (extended) orthonormal basis vector matrix `V` may be specified
+as `VType`. This is required e. g. for `GPUArray`s. 
+
+`U` determines`eltype(H)`.
+
+
     getV(Ks) -> V
     getH(Ks) -> H
 
-The type of the basis vector matrix `V` may be specified as `VType`. This is required
-e. g. for `GPUArray`s. `U` determines`eltype(H)`.
 
 Access methods for the (extended) orthonormal basis `V` and the (extended)
 Gram-Schmidt coefficients `H`. Both methods return a view into the storage

--- a/src/arnoldi.jl
+++ b/src/arnoldi.jl
@@ -19,8 +19,7 @@ as `VType`. This is required e. g. for `GPUArray`s.
 
     getV(Ks) -> V
     getH(Ks) -> H
-
-
+    
 Access methods for the (extended) orthonormal basis `V` and the (extended)
 Gram-Schmidt coefficients `H`. Both methods return a view into the storage
 arrays and has the correct dimensions as indicated by `Ks.m`.

--- a/src/arnoldi.jl
+++ b/src/arnoldi.jl
@@ -4,6 +4,7 @@
 # Output type/cache
 """
     KrylovSubspace{T}(n,[maxiter=30]) -> Ks
+    KrylovSubspace{T,U, VType}(n,[maxiter=30]) -> Ks
 
 Constructs an uninitialized Krylov subspace, which can be filled by `arnoldi!`.
 
@@ -12,6 +13,9 @@ be smaller than `maxiter`, the maximum allowed arnoldi iterations.
 
     getV(Ks) -> V
     getH(Ks) -> H
+
+The type of the basis vector matrix `V` may be specified as `VType`. This is required
+e. g. for `GPUArray`s. `U` determines`eltype(H)`.
 
 Access methods for the (extended) orthonormal basis `V` and the (extended)
 Gram-Schmidt coefficients `H`. Both methods return a view into the storage

--- a/src/arnoldi.jl
+++ b/src/arnoldi.jl
@@ -19,7 +19,7 @@ as `VType`. This is required e. g. for `GPUArray`s.
 
     getV(Ks) -> V
     getH(Ks) -> H
-    
+
 Access methods for the (extended) orthonormal basis `V` and the (extended)
 Gram-Schmidt coefficients `H`. Both methods return a view into the storage
 arrays and has the correct dimensions as indicated by `Ks.m`.

--- a/src/arnoldi.jl
+++ b/src/arnoldi.jl
@@ -47,7 +47,7 @@ function KrylovSubspace{T, U, VType}(n::Integer, maxiter::Integer = 30,
     V = VType(undef, n + augmented, maxiter + 1)
     H = fill(zero(U), maxiter + 1, maxiter + !iszero(augmented))
     return KrylovSubspace{T, U, real(T), VType, Matrix{U}}(maxiter, maxiter, augmented,
-    zero(real(T)), false, V, H)
+        zero(real(T)), false, V, H)
 end
 
 KrylovSubspace{T}(args...) where {T} = KrylovSubspace{T, T}(args...)

--- a/src/arnoldi.jl
+++ b/src/arnoldi.jl
@@ -14,7 +14,7 @@ be smaller than `maxiter`, the maximum allowed arnoldi iterations.
 The type of the (extended) orthonormal basis vector matrix `V` may be specified
 as `VType`. This is required e. g. for `GPUArray`s. 
 
-`U` determines`eltype(H)`.
+`U` determines `eltype(H)`.
 
 
     getV(Ks) -> V

--- a/src/arnoldi.jl
+++ b/src/arnoldi.jl
@@ -34,15 +34,16 @@ mutable struct KrylovSubspace{T, U, B, VType <: AbstractMatrix{T},
     H::HType  # Gram-Schmidt coefficients (real for Hermitian matrices)
 end
 
-function KrylovSubspace{T, U}(n::Integer, maxiter::Integer = 30,
-        augmented::Integer = false) where {T, U}
-    V = Matrix{T}(undef, n + augmented, maxiter + 1)
+function KrylovSubspace{T, U, VType}(n::Integer, maxiter::Integer = 30,
+        augmented::Integer = false) where {T, U, VType <: AbstractMatrix{T}}
+    V = VType(undef, n + augmented, maxiter + 1)
     H = fill(zero(U), maxiter + 1, maxiter + !iszero(augmented))
-    return KrylovSubspace{T, U, real(T), Matrix{T}, Matrix{U}}(maxiter, maxiter, augmented,
-        zero(real(T)), false, V, H)
+    return KrylovSubspace{T, U, real(T), VType, Matrix{U}}(maxiter, maxiter, augmented,
+    zero(real(T)), false, V, H)
 end
 
 KrylovSubspace{T}(args...) where {T} = KrylovSubspace{T, T}(args...)
+KrylovSubspace{T,U}(args...) where {T,U} = KrylovSubspace{T, U, Matrix{T}}(args...)
 
 getV(Ks::KrylovSubspace) = @view(Ks.V[:, 1:(Ks.m + 1)])
 getH(Ks::KrylovSubspace) = @view(Ks.H[1:(Ks.m + 1), 1:(Ks.m + !iszero(Ks.augmented))])


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context
Allow for overriding the type of the basis vector matrix `V` used for the KrylovSubspace. `V` has to be a GPUArray if  `arnoldi!(Ks,A,b)` is executed for `b` being GPUArray.
