### PR TITLE
Don't check for breakdown if adaptive=false

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ExponentialUtilities"
 uuid = "d4d017d3-3776-5f7e-afef-a10c40355c18"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "José E. Cruz Serrallés <Jose.CruzSerralles@nyulangone.org>"]
-version = "1.27.0"
+version = "1.27.1"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/krylov_phiv_adaptive.jl
+++ b/src/krylov_phiv_adaptive.jl
@@ -74,7 +74,7 @@ Niesen & Wright is used, the relative tolerance of which can be set using the
 keyword parameter `tol`. The delta and gamma parameters of the adaptation
 scheme can also be adjusted.
 
-When encountering a happy breakdown in the Krylov subspace construction, the
+When encountering a happy breakdown in the Krylov subspace construction and `adaptive=true`, the
 time step is set to the remainder of the time interval since time stepping is
 no longer necessary.
 
@@ -180,7 +180,7 @@ function phiv_timestep!(U::AbstractMatrix{T}, ts::Vector{tType}, A, B::AbstractM
         end
         # Part 2: compute ϕp(tau*A)wp using Krylov, possibly with adaptation
         arnoldi!(Ks, A, @view(W[:, end]); tol = tol, m = m, opnorm = opnorm, iop = iop)
-        if Ks.wasbreakdown
+        if adaptive && Ks.wasbreakdown
             tau = tend - t
         end
         _, epsilon = phiv!(P, tau, Ks, p + 1; cache = phiv_cache, correct = correct,

--- a/test/basictests.jl
+++ b/test/basictests.jl
@@ -119,13 +119,13 @@ end
     if VERSION >= v"1.7"
         out = Pipe()
         res = redirect_stdout(out) do
-            expv_timestep(ts, reshape([1], (1, 1)), [1.0]; verbose = true)
+            expv_timestep(ts, reshape([1], (1, 1)), [1.0]; verbose = true, adaptive = true)
         end
         close(Base.pipe_writer(out))
 
         @test occursin("Completed after 1 time step(s)", read(out, String))
     else
-        res = expv_timestep(ts, reshape([1], (1, 1)), [1.0]; verbose = true)
+        res = expv_timestep(ts, reshape([1], (1, 1)), [1.0]; verbose = true, adaptive = true)
     end
 
     @test vec(res) ≈ exp.(ts)


### PR DESCRIPTION
This changes `phiv_timestep` to no longer check for a happy-breakdown if `adaptive=false`.

## Checklist

- [ ] Appropriate tests were added

I'm not sure what example to come up with to get a new direct test for this. The only example I have is from private code.

- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API

