### PR TITLE
Remove outdated Julia version checks

### DIFF
--- a/src/exp_noalloc.jl
+++ b/src/exp_noalloc.jl
@@ -38,7 +38,7 @@ end
 const RHO_V = (0.015, 0.25, 0.95, 2.1, 5.4, 10.8, 21.6, 43.2, 86.4, 172.8, 345.6, 691.2)
 
 # From LinearAlgebra
-const LIBLAPACK = VERSION >= v"1.7" ? BLAS.libblastrampoline : LAPACK.liblapack
+const LIBLAPACK = BLAS.libblastrampoline
 using LinearAlgebra: BlasInt, checksquare
 for (gebal, gebak, elty, relty) in ((:dgebal_, :dgebak_, :Float64, :Float64),
     (:sgebal_, :sgebak_, :Float32, :Float32),

--- a/test/basictests.jl
+++ b/test/basictests.jl
@@ -96,11 +96,9 @@ exp_generic(A) = exponential!(copy(A), ExpMethodGeneric())
     end
 end
 
-if VERSION >= v"1.9"
-    @testset "exponential! sparse" begin
-        A = sparse([1, 2, 1], [2, 1, 1], [1.0, 2.0, 3.0])
-        @test_throws ErrorException exponential!(A)
-    end
+@testset "exponential! sparse" begin
+    A = sparse([1, 2, 1], [2, 1, 1], [1.0, 2.0, 3.0])
+    @test_throws ErrorException exponential!(A)
 end
 
 @testset "Issue 41" begin
@@ -116,17 +114,13 @@ end
 @testset "Issue 143" begin
     ts = collect(0:0.1:1)
 
-    if VERSION >= v"1.7"
-        out = Pipe()
-        res = redirect_stdout(out) do
-            expv_timestep(ts, reshape([1], (1, 1)), [1.0]; verbose = true)
-        end
-        close(Base.pipe_writer(out))
-
-        @test occursin("Completed after 1 time step(s)", read(out, String))
-    else
-        res = expv_timestep(ts, reshape([1], (1, 1)), [1.0]; verbose = true)
+    out = Pipe()
+    res = redirect_stdout(out) do
+        expv_timestep(ts, reshape([1], (1, 1)), [1.0]; verbose = true)
     end
+    close(Base.pipe_writer(out))
+
+    @test occursin("Completed after 1 time step(s)", read(out, String))
 
     @test vec(res) ≈ exp.(ts)
 end


### PR DESCRIPTION
## Summary
Since Julia v1.10 is now the LTS, version checks for v1.7 and v1.9 are no longer needed.

## Changes
- Removed v1.9 check for exponential\! sparse test (test removed entirely)
- Removed v1.7 check for redirect_stdout in Issue 143 test (now always uses redirect_stdout)
- Removed v1.7 check for LIBLAPACK selection (now always uses BLAS.libblastrampoline)

## Test plan
- [ ] Tests pass locally
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.ai/code)