### PR TITLE
Remove V100 CUDA compatibility workarounds

### DIFF
--- a/test/gpu/LocalPreferences.toml
+++ b/test/gpu/LocalPreferences.toml
@@ -1,7 +1,0 @@
-[CUDA_Runtime_jll]
-version = "12.6"
-
-[CUDA_Driver_jll]
-# Disable forward-compat driver — V100 runners need the system driver
-# since CUDA_Driver_jll v13+ drops compute capability 7.0 support
-compat = "false"

--- a/test/gpu/Project.toml
+++ b/test/gpu/Project.toml
@@ -1,7 +1,5 @@
 [deps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
-CUDA_Driver_jll = "4ee394cb-3365-5eb0-8335-949819d2adfc"
-CUDA_Runtime_jll = "76a88914-d11a-5bdc-97e0-2f5a05c973a2"
 
 [compat]
-CUDA = "4, 5"
+CUDA = "3.12, 4, 5"


### PR DESCRIPTION
## Summary
- Remove `LocalPreferences.toml` that pinned CUDA runtime to 12.6 for V100 compatibility
- Remove `CUDA_Driver_jll` and `CUDA_Runtime_jll` dependency additions from test Project.toml
- Restore original CUDA compat bounds

demeter4's driver has been downgraded to CUDA 12.9 (from 13.x), so these workarounds are no longer needed. The CUDA 12.x driver will automatically select a compatible toolkit for the V100s.

Reverts the workaround parts of #214.

🤖 Generated with [Claude Code](https://claude.com/claude-code)