### PR TITLE
Centralize CI on SciML reusable workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,6 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-    ignore:
-      - dependency-name: "crate-ci/typos"
-        update-types: ["version-update:semver-patch", "version-update:semver-minor"]
   - package-ecosystem: "julia"
     directories:
       - "/"

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -11,27 +11,17 @@ on:
     paths-ignore:
       - 'docs/**'
 jobs:
-  test:
+  downgrade:
     if: false  # Disabled pending fix - see #208 for tracking re-enablement
-    runs-on: ubuntu-latest
+    name: "Downgrade"
     strategy:
       matrix:
         group:
           - Core
-        downgrade_mode: ['alldeps']
-        julia-version: ['1.10']
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: ${{ matrix.julia-version }}
-      - uses: julia-actions/julia-downgrade-compat@v2
-#        if: ${{ matrix.version == '1.6' }}
-        with:
-          skip: Pkg,TOML
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
-        with:
-          ALLOW_RERESOLVE: false
-        env:
-          GROUP: ${{ matrix.group }}
+    uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
+    with:
+      julia-version: "1.10"
+      group: "${{ matrix.group }}"
+      skip: "Pkg,TOML"
+      allow-reresolve: false
+    secrets: "inherit"

--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -12,11 +12,8 @@ on:
       - 'docs/**'
 
 jobs:
-  test:
-    name: ${{ matrix.package.repo }}/${{ matrix.package.group }}/${{ matrix.julia-version }}
-    runs-on: ${{ matrix.os }}
-    env:
-      GROUP: ${{ matrix.package.group }}
+  downstream:
+    name: "Downstream"
     strategy:
       fail-fast: false
       matrix:
@@ -26,46 +23,15 @@ jobs:
           - {user: SciML, repo: OrdinaryDiffEq.jl, group: InterfaceIII}
           - {user: SciML, repo: OrdinaryDiffEq.jl, group: InterfaceIV}
           - {user: SciML, repo: OrdinaryDiffEq.jl, group: InterfaceV}
-        version:
-          - '1'
         os:
           - ubuntu-latest
           - macos-latest
           - windows-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: ${{ matrix.version }}
-      - uses: julia-actions/julia-buildpkg@latest
-      - name: Clone Downstream
-        uses: actions/checkout@v6
-        with:
-          repository: ${{ matrix.package.user }}/${{ matrix.package.repo }}
-          path: downstream
-      - uses: julia-actions/cache@v3
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Load this and run the downstream tests
-        shell: julia --color=yes --depwarn=error --project=downstream {0}
-        run: |
-          using Pkg
-          try
-            # force it to use this PR's version of the package
-            Pkg.develop(PackageSpec(path="."))  # resolver may fail with main deps
-            Pkg.update()
-            Pkg.test(coverage=true)  # resolver may fail with test time deps
-          catch err
-            err isa Pkg.Resolve.ResolverError || rethrow()
-            # If we can't resolve that means this is incompatible by SemVer and this is fine
-            # It means we marked this as a breaking change, so we don't need to worry about
-            # Mistakenly introducing a breaking change, as we have intentionally made one
-            @info "Not compatible with this release. No problem." exception=err
-            exit(0)  # Exit immediately, as a success
-          end
-      - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v6
-        with:
-          files: lcov.info
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: true
+    uses: "SciML/.github/.github/workflows/downstream.yml@v1"
+    with:
+      julia-version: "1"
+      owner: "${{ matrix.package.user }}"
+      repo: "${{ matrix.package.repo }}"
+      group: "${{ matrix.package.group }}"
+      os: "${{ matrix.os }}"
+    secrets: "inherit"

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -11,12 +11,6 @@ on:
 
 jobs:
   runic:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: '1'
-      - uses: fredrikekre/runic-action@v1
-        with:
-          version: '1'
+    name: "Runic"
+    uses: "SciML/.github/.github/workflows/runic.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -4,10 +4,6 @@ on: [pull_request]
 
 jobs:
   typos-check:
-    name: Spell Check with Typos
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Actions Repository
-        uses: actions/checkout@v6
-      - name: Check spelling
-        uses: crate-ci/typos@v1.18.1 
+    name: "Spell Check with Typos"
+    uses: "SciML/.github/.github/workflows/spellcheck.yml@v1"
+    secrets: "inherit"

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,4 +1,7 @@
 [default.extend-words]
+# Algorithm cost/order variables (matrix exponential scaling-and-squaring)
+Cmo = "Cmo"
+Cmp = "Cmp"
 # Julia-specific functions
 indexin = "indexin"
 findfirst = "findfirst"


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

Converts the remaining inline CI checks to the SciML centralized reusable workflows. Every caller is pinned to `@v1` and passes `secrets: "inherit"`.

## Converted (inline -> central caller)
- **FormatCheck.yml**: `fredrikekre/runic-action` -> `runic.yml@v1`
- **SpellCheck.yml**: `crate-ci/typos` -> `spellcheck.yml@v1`
- **Downgrade.yml**: inline -> `downgrade.yml@v1`, preserving `group: Core`, `julia-version: 1.10`, `skip: Pkg,TOML`, `allow-reresolve: false`, and the `if: false` gate (still disabled pending #208)
- **Downstream.yml**: inline -> matrix of `downstream.yml@v1` callers, preserving the 5 OrdinaryDiffEq.jl groups (InterfaceI..V) x 3 OS (ubuntu/macos/windows)

## Left unchanged
- **Tests.yml** and **Documentation.yml** were already central callers with `secrets: "inherit"`.
- **GPU.yml** left inline (no centralized GPU caller exists).
- **TagBot.yml** unchanged.

## Other
- Removed the `crate-ci/typos` ignore from `dependabot.yml` so the action tracks updates again. Julia + github-actions dependabot blocks preserved.
- Added `Cmo`/`Cmp` (matrix-exponential cost/order variables in `ext/ExponentialUtilitiesStaticArraysExt.jl`) to `.typos.toml` to silence false positives. No prose or identifiers were mass-edited.

## Verification (run locally)
- Runic v1.7.0 `--check .` -> exit 0 (already clean; no formatting changes).
- typos-cli 1.47.0 (matches the central spellcheck pin) `.` -> exit 0.

## Typos fixed
0 (the only findings were the `Cmo`/`Cmp` identifiers, handled via `.typos.toml`).

## Warning
Check names change (e.g. the Runic job is now "Runic Format Check", spell check is "Spell Check with Typos", downgrade/downstream job names change). **Branch-protection required-status-check names will need updating** after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)