### PR TITLE
ci: add standard centralized workflows (auto-format, dependabot-automerge, docs-preview-cleanup)

### DIFF
--- a/.github/workflows/DependabotAutoMerge.yml
+++ b/.github/workflows/DependabotAutoMerge.yml
@@ -1,0 +1,9 @@
+name: "Dependabot Auto-merge"
+on: pull_request
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  automerge:
+    uses: "SciML/.github/.github/workflows/dependabot-automerge.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/DocPreviewCleanup.yml
+++ b/.github/workflows/DocPreviewCleanup.yml
@@ -1,0 +1,10 @@
+name: "Doc Preview Cleanup"
+on:
+  pull_request:
+    types: [closed]
+permissions:
+  contents: write
+jobs:
+  cleanup:
+    uses: "SciML/.github/.github/workflows/docs-preview-cleanup.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/RunicSuggestions.yml
+++ b/.github/workflows/RunicSuggestions.yml
@@ -1,0 +1,9 @@
+name: "Runic Suggestions"
+on: pull_request
+permissions:
+  contents: read
+  pull-requests: write
+jobs:
+  runic-suggestions:
+    uses: "SciML/.github/.github/workflows/runic-suggestions-on-pr.yml@v1"
+    secrets: "inherit"


### PR DESCRIPTION
Adds the standard SciML centralized caller workflows that were missing from this repo. No existing workflows were modified.

Workflows added:
- **RunicSuggestions.yml** — auto-format (Runic) suggestions on PRs (repo's format check uses `runic.yml@v1`).
- **DependabotAutoMerge.yml** — auto-merge Dependabot PRs.
- **DocPreviewCleanup.yml** — clean up Documenter doc previews when PRs close (repo has a `docs/` Documenter site).

These are static caller files referencing `SciML/.github/.github/workflows/...@v1`; no local test runs are applicable.

**Please ignore this PR until reviewed by @ChrisRackauckas.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)