### PR TITLE
Canonical CI cleanup: TagBot thin-caller + downgrade-caller cleanup

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -19,7 +19,6 @@ jobs:
           - Core
     uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
     with:
-      julia-version: "1.10"
+      julia-version: "lts"
       group: "${{ matrix.group }}"
-      skip: "Pkg,TOML"
     secrets: "inherit"

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,15 +1,9 @@
-name: TagBot
+name: "TagBot"
 on:
   issue_comment:
-    types:
-      - created
+    types: [created]
   workflow_dispatch:
 jobs:
-  TagBot:
-    if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: JuliaRegistries/TagBot@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          ssh: ${{ secrets.DOCUMENTER_KEY }}
+  tagbot:
+    uses: "SciML/.github/.github/workflows/tagbot.yml@v1"
+    secrets: "inherit"


### PR DESCRIPTION
Canonical CI cleanup.

- **TagBot.yml**: replaced the inlined `JuliaRegistries/TagBot@v1` job (permissions + steps) with the canonical thin caller `SciML/.github/.github/workflows/tagbot.yml@v1` (single-package form; this repo is not a monorepo).
- **Downgrade.yml**: dropped the `skip:` input (it only listed stdlibs `Pkg,TOML`, now auto-populated by the central workflow) and changed `julia-version: "1.10"` to `"lts"`.
Static-validated: edited YAML parses and the TOML parses.

Ignore until reviewed by @ChrisRackauckas.