### PR TITLE
Allow CUDA.jl v6 in GPU test environment

### DIFF
--- a/test/gpu/Project.toml
+++ b/test/gpu/Project.toml
@@ -5,7 +5,7 @@ SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-CUDA = "3.12, 4, 5"
+CUDA = "6"
 SafeTestsets = "0.1, 1"
 SciMLTesting = "1"
 Test = "1"


### PR DESCRIPTION
## Summary

The GPU test environment pins CUDA.jl to `"3.12, 4, 5"`. The V100 GPU CI runners now run nvidia driver 580, which requires CUDA.jl **v6.2+** — versions below 6.2 select the CUDA runtime based on the driver version and pick an incompatible runtime, causing GPU CI to fail. The fix landed in [JuliaGPU/CUDA.jl#3134](https://github.com/JuliaGPU/CUDA.jl/pull/3134) (see also [issue #3079](https://github.com/JuliaGPU/CUDA.jl/issues/3079)).

This widens the CUDA compat in the GPU test environment to `"6"` so the resolver picks the latest 6.x (currently ≥6.2), which contains the runtime-selection fix.

## Changes

- Bump `CUDA` compat from `"3.12, 4, 5"` to `"6"` in `test/gpu/Project.toml`.

Test-environment-only; no package compat or version is affected.
