### PR TITLE
Fall back to ExpMethodGeneric for immutable matrices in exponential!

### DIFF
--- a/src/exp.jl
+++ b/src/exp.jl
@@ -10,7 +10,15 @@ function alloc_mem(A, method)
     return nothing
 end
 
-exponential!(A) = exponential!(A, ExpMethodHigham2005(A));
+# Immutable matrices (e.g. StaticArrays' SMatrix) cannot use the in-place
+# ExpMethodHigham2005 default, so route them to the non-mutating generic method.
+function exponential!(A)
+    return if ismutable(A)
+        exponential!(A, ExpMethodHigham2005(A))
+    else
+        exponential!(A, ExpMethodGeneric())
+    end
+end
 function exponential!(A::GPUArraysCore.AbstractGPUArray)
     return exponential!(A, ExpMethodHigham2005(false))
 end;
@@ -32,6 +40,10 @@ ExpMethodDiagonalization() = ExpMethodDiagonalization(true);
 Computes the matrix exponential with the method specified in `method`. The contents of `A` are modified, allowing for fewer allocations. The `method` parameter specifies the implementation and implementation parameters, e.g. [`ExpMethodNative`](@ref), [`ExpMethodDiagonalization`](@ref), [`ExpMethodGeneric`](@ref), [`ExpMethodHigham2005`](@ref). Memory
 needed can be preallocated and provided in the parameter `cache` such that the memory can be recycled when calling `exponential!` several times. The preallocation is done with the command [`alloc_mem`](@ref): `cache=alloc_mem(A,method)`.
 `A` may not be sparse matrix type, since exp(A) is likely to be dense.
+
+If no `method` is given, immutable matrices (e.g. StaticArrays' `SMatrix`) are
+computed out-of-place with [`ExpMethodGeneric`](@ref) and the result is returned
+without modifying `A`.
 
 Example
 

--- a/test/basictests.jl
+++ b/test/basictests.jl
@@ -97,6 +97,21 @@ exp_generic(A) = exponential!(copy(A), ExpMethodGeneric())
     end
 end
 
+@testset "exponential! on immutable (static) matrices" begin
+    for (n, T) in ((3, Float64), (4, Float64), (3, Float32), (4, Float32))
+        A = rand(SMatrix{n, n, T})
+        E = exponential!(A)
+        @test E isa SMatrix{n, n}
+        @test E ≈ exp(Matrix(A))
+        @test !any(isnan, E)
+
+        J = ForwardDiff.jacobian(exponential!, A)
+        Jref = ForwardDiff.jacobian(exp_generic, Matrix(A))
+        @test !any(isnan, J)
+        @test J ≈ Jref
+    end
+end
+
 @testset "exponential! sparse" begin
     A = sparse([1, 2, 1], [2, 1, 1], [1.0, 2.0, 3.0])
     @test_throws ErrorException exponential!(A)


### PR DESCRIPTION
> [!NOTE]
> This PR should be ignored until reviewed by @ChrisRackauckas.

## What

`exponential!(A)` with no method argument now falls back to `ExpMethodGeneric()` when `A` is immutable (per `ArrayInterface.ismutable`, the same predicate `ExpMethodGeneric` uses internally), instead of always selecting the in-place `ExpMethodHigham2005`.

## Why

`exponential!(A)` on a StaticArrays `SMatrix` currently throws:

```
setindex!(::SMatrix{4, 4, Float64, 16}, value, ::Int) is not defined.
```

because the default `ExpMethodHigham2005` path mutates. Meanwhile `ExpMethodGeneric` already contains a fully non-mutating code path for immutable inputs (the `ismutable(x)` guard in `src/exp_generic.jl`), so the capability exists — it just isn't reachable from the no-method entry point.

This came out of https://discourse.julialang.org/t/how-to-use-forwarddiff-jl-with-inv-and-matrix-exponential/137880, where the recommendation to use the (now-removed name) `exp_generic` on static arrays failed with the error above.

Two additional data points verified locally while preparing this:

- `ForwardDiff.jacobian(exponential!, ::SMatrix)` works through the new fallback and matches finite differences (~1e-7) for 3×3/4×4, Float64 and Float32.
- For `SMatrix{3,3,Float32}`, StaticArrays' own `exp` gives NaN Jacobians in ~1/3 of random samples (its Base-style Padé coefficients, up to ~3.2e16, overflow Float32 through the 3×3 cofactor solve — as diagnosed by mikmoore on Discourse). `ExpMethodGeneric` gave 0 NaNs in 1000 samples because its Padé coefficients are normalized (≤ 1). So the fallback is also the numerically safer path for Float32 static arrays, not just the one that doesn't error.

## Changes

- `src/exp.jl`: default method selection routes immutable matrices to `ExpMethodGeneric()`; docstring note added.
- `test/basictests.jl`: new testset covering `exponential!(::SMatrix)` values vs `exp(Matrix(A))` and `ForwardDiff.jacobian` vs the `Matrix` reference, for 3×3/4×4 × Float64/Float32, including NaN checks.

Behavior note: scalars also now work through the no-method entry point (`ismutable(::Number) == false` → `ExpMethodGeneric`), where previously `exponential!(1.0)` threw a `MethodError`. Purely additive.

## Testing

`GROUP=Core Pkg.test()` run locally on Julia 1.11.9: `Core/basictests.jl | 349 passed, 1 broken (pre-existing kiops @test_broken), 0 failures`. Runic applied to the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WQWjLDJ228E8w9631ZeTdM
