### PR TITLE
Preserve input element type in ExpMethodGeneric (fix Float32 → Float64 promotion)

### DIFF
--- a/src/exp_generic.jl
+++ b/src/exp_generic.jl
@@ -232,22 +232,41 @@ function exponential!(
     end
 end
 
+# Specialized (13,13) Padé numerator for the immutable-matrix path. The coefficient
+# type is taken from `eltype(x)` at runtime (rather than hardcoded `Float64`) so that a
+# Float32 input yields a Float32 result instead of being silently promoted to Float64.
+# This is deliberately not `@generated`: deriving the type inside a generated body would
+# require constructing the element type (e.g. a ForwardDiff `Dual`), which is world-age
+# blocked, so ForwardDiff differentiation would fail.
 function exp_pade_p(x, ::Val{13}, ::Val{13})
+    T = float(eltype(x))
     return @evalpoly(
-        x, LinearAlgebra.UniformScaling{Float64}(1.0),
-        LinearAlgebra.UniformScaling{Float64}(0.5),
-        LinearAlgebra.UniformScaling{Float64}(0.12),
-        LinearAlgebra.UniformScaling{Float64}(0.018333333333333333),
-        LinearAlgebra.UniformScaling{Float64}(0.0019927536231884057),
-        LinearAlgebra.UniformScaling{Float64}(0.00016304347826086958),
-        LinearAlgebra.UniformScaling{Float64}(1.0351966873706003e-5),
-        LinearAlgebra.UniformScaling{Float64}(5.175983436853002e-7),
-        LinearAlgebra.UniformScaling{Float64}(2.0431513566525008e-8),
-        LinearAlgebra.UniformScaling{Float64}(6.306022705717595e-10),
-        LinearAlgebra.UniformScaling{Float64}(1.48377004840414e-11),
-        LinearAlgebra.UniformScaling{Float64}(2.529153491597966e-13),
-        LinearAlgebra.UniformScaling{Float64}(2.8101705462199623e-15),
-        LinearAlgebra.UniformScaling{Float64}(1.5440497506703088e-17)
+        x,
+        UniformScaling(T(1 // 1)),
+        UniformScaling(T(1 // 2)),
+        UniformScaling(T(3 // 25)),
+        UniformScaling(T(11 // 600)),
+        UniformScaling(T(11 // 5520)),
+        UniformScaling(T(3 // 18400)),
+        UniformScaling(T(1 // 96600)),
+        UniformScaling(T(1 // 1932000)),
+        UniformScaling(T(1 // 48944000)),
+        UniformScaling(T(1 // 1585785600)),
+        UniformScaling(T(1 // 67395888000)),
+        UniformScaling(T(1 // 3953892096000)),
+        UniformScaling(T(1 // 355850288640000)),
+        UniformScaling(T(1 // 64764752532480000))
+    )
+end
+
+function exp_pade_p(x::Number, ::Val{13}, ::Val{13})
+    T = float(typeof(x))
+    return @evalpoly(
+        x,
+        T(1 // 1), T(1 // 2), T(3 // 25), T(11 // 600), T(11 // 5520),
+        T(3 // 18400), T(1 // 96600), T(1 // 1932000), T(1 // 48944000),
+        T(1 // 1585785600), T(1 // 67395888000), T(1 // 3953892096000),
+        T(1 // 355850288640000), T(1 // 64764752532480000)
     )
 end
 
@@ -311,15 +330,6 @@ function exp_pade_p!(
         y1[n, n] += one(T)
     end
     return y1
-end
-
-function exp_pade_p(x::Number, ::Val{13}, ::Val{13})
-    return @evalpoly(
-        x, 1.0, 0.5, 0.12, 0.018333333333333333, 0.0019927536231884057,
-        0.00016304347826086958, 1.0351966873706003e-5, 5.175983436853002e-7,
-        2.0431513566525008e-8, 6.306022705717595e-10, 1.48377004840414e-11,
-        2.529153491597966e-13, 2.8101705462199623e-15, 1.5440497506703088e-17
-    )
 end
 
 @generated function exp_pade_p(x, ::Val{k}, ::Val{m}) where {k, m}

--- a/test/basictests.jl
+++ b/test/basictests.jl
@@ -112,6 +112,28 @@ end
     end
 end
 
+@testset "ExpMethodGeneric preserves element type (immutable matrices)" begin
+    # https://discourse.julialang.org/t/137880 : ExpMethodGeneric silently promoted
+    # Float32 static matrices to Float64. The (13,13) Padé path must keep the input type.
+    for (n, T) in ((2, Float32), (3, Float32), (2, Float64), (3, Float64))
+        A = rand(SMatrix{n, n, T})
+        E = exponential!(A, ExpMethodGeneric())
+        @test E isa SMatrix{n, n, T}
+        @test Float64.(E) ≈ exp(Float64.(Matrix(A))) rtol = sqrt(eps(T))
+
+        J = ForwardDiff.jacobian(x -> exponential!(x, ExpMethodGeneric()), A)
+        @test eltype(J) === T
+    end
+
+    # ComplexF32 must stay ComplexF32
+    Ac = rand(SMatrix{2, 2, ComplexF32})
+    @test exponential!(Ac, ExpMethodGeneric()) isa SMatrix{2, 2, ComplexF32}
+
+    # Scalar path likewise preserves precision
+    @test exponential!(0.5f0, ExpMethodGeneric()) isa Float32
+    @test ForwardDiff.derivative(x -> exponential!(x, ExpMethodGeneric()), 0.3f0) isa Float32
+end
+
 @testset "exponential! sparse" begin
     A = sparse([1, 2, 1], [2, 1, 1], [1.0, 2.0, 3.0])
     @test_throws ErrorException exponential!(A)

--- a/test/basictests.jl
+++ b/test/basictests.jl
@@ -132,6 +132,24 @@ end
     # Scalar path likewise preserves precision
     @test exponential!(0.5f0, ExpMethodGeneric()) isa Float32
     @test ForwardDiff.derivative(x -> exponential!(x, ExpMethodGeneric()), 0.3f0) isa Float32
+
+    # The (13,13) Padé coefficients are exact rationals, so an immutable Double64 matrix
+    # must reach full Double64 accuracy. Hardcoded Float64 coefficients capped this at
+    # eps(Float64) (~1e-16); with exact rationals it reaches eps(Double64) (~5e-32).
+    Ad = SMatrix{2, 2, Double64}(
+        Double64(9 // 10), Double64(2 // 10),
+        Double64(3 // 10), Double64(7 // 10)
+    )
+    Rd = exponential!(Ad, ExpMethodGeneric())
+    setprecision(BigFloat, 300) do
+        Ab = BigFloat[9 // 10 3 // 10; 2 // 10 7 // 10]
+        sc = Ab ./ BigFloat(2)^50
+        ref = sum(sc^n / factorial(big(n)) for n in 0:80)
+        for _ in 1:50
+            ref = ref * ref
+        end
+        @test maximum(abs.(BigFloat.(Rd) .- ref)) < 1.0e-28
+    end
 end
 
 @testset "exponential! sparse" begin


### PR DESCRIPTION
> **Please ignore until reviewed by @ChrisRackauckas.** Draft opened by an agent.

## Problem

Reported on Discourse: [How to use ForwardDiff.jl with `inv` and matrix exponential (post #15)](https://discourse.julialang.org/t/how-to-use-forwarddiff-jl-with-inv-and-matrix-exponential/137880/15).

`exponential!(x, ExpMethodGeneric())` silently promotes `Float32` inputs to `Float64`:

```julia
julia> A = rand(SMatrix{3,3,Float32});

julia> exponential!(A, ExpMethodGeneric()) |> eltype
Float64            # expected Float32

julia> ForwardDiff.jacobian(x -> exponential!(x, ExpMethodGeneric()), A) |> eltype
Float64            # expected Float32
```

## Cause

The specialized `(13,13)` Padé numerator methods hardcoded `Float64` coefficients — `UniformScaling{Float64}(...)` for the immutable-matrix path and `Float64` literals for the scalar path — forcing the whole `@evalpoly` Horner evaluation to promote to `Float64` regardless of input type. (Only the immutable/`SMatrix` path hits these; mutable dense matrices go through `exp_generic_mutable`.)

## Fix

Take the coefficient type from `float(eltype(x))` (matrix) / `float(typeof(x))` (scalar) at runtime, using the **exact Padé rationals** `c_j = (k+m-j)! k! / ((k+m)! (k-j)! j!)`.

These coefficients are *genuinely* rational, not float rationalizations:

- The defining Padé identity `exp(x)·q(x) − p(x) = O(x^27)` holds **exactly** in rational arithmetic (all 27 residual Taylor coefficients through degree 26 are `0//1`).
- The old hardcoded literals equal `Float64(c_j)` bit-for-bit — they were roundings *of* the rationals.

So `T(p//q)` states the true (exact) precision and rounds to `T`. For `Float64` this reproduces the old literals bit-for-bit (results unchanged), while `Float32`, `ComplexF32`, `Double64`, and ForwardDiff `Dual` inputs keep their type. This is also what the package's own `@generated exp_pade_p(x, ::Val{k}, ::Val{m})` already does for non-13 orders.

The precision recovered is real, measured on an immutable `Double64` matrix vs a 400-bit BigFloat reference:

| coefficients | max error | ≈ |
|---|---|---|
| exact rational → `Double64` (this PR) | **1.6e-32** | `eps(Double64)` |
| `Float64` literals → `Double64` (before) | **2.9e-18** | `eps(Float64)` |

This is deliberately **not** `@generated`: deriving the coefficient type inside a generated body requires constructing the element type (e.g. a ForwardDiff `Dual`), which is world-age blocked and breaks differentiation — which is why the existing generic `@generated` method could not simply be reused for the default `k = 13` case.

## Scope / follow-up

Only the **immutable** path is fixed here. A dense (mutable) matrix goes through `exp_generic_mutable` → in-place `exp_pade_p!`, which still uses `Float64` literals and forces `promote_type(T, Float64)`. So dense `Double64` matrices remain `Float64`-limited and a dense `Float32` matrix still returns `Float64`. Same root cause; can be a stacked follow-up if wanted.

## Tests

Added a testset asserting element-type preservation for `ExpMethodGeneric` across `Float32`/`Float64` static matrices (result eltype **and** ForwardDiff jacobian eltype), `ComplexF32`, the scalar path, plus a `Double64` immutable-matrix accuracy check (reaches `eps(Double64)`, guarding the exact-rational property). Full suite passes locally on Julia 1.10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
