### PR TITLE
Document public API: add docstrings + docs entries

### DIFF
--- a/docs/src/expv.md
+++ b/docs/src/expv.md
@@ -30,6 +30,7 @@ expv_timestep
 phiv_timestep
 expv_timestep!
 phiv_timestep!
+kiops
 ```
 
 ## Caches
@@ -37,4 +38,6 @@ phiv_timestep!
 ```@docs
 ExponentialUtilities.ExpvCache
 ExponentialUtilities.PhivCache
+ExponentialUtilities.StegrCache
+ExponentialUtilities.get_subspace_cache
 ```

--- a/src/krylov_phiv.jl
+++ b/src/krylov_phiv.jl
@@ -2,6 +2,21 @@
 
 ############################
 # Cache for expv
+"""
+    ExpvCache{T}(maxiter::Int)
+
+Reusable scratch workspace for the in-place [`expv!`](@ref) Krylov
+matrix-exponential-vector product with element type `T`. It holds a single flat
+buffer sized for an `maxiter`×`maxiter` Hessenberg matrix; pass the cache as the
+`cache` keyword to `expv!` to avoid reallocating that buffer on repeated calls.
+The buffer is grown automatically (via `resize!`) if a later call requests a
+larger subspace than the one it was allocated for.
+
+# Fields
+
+  - `mem::Vector{T}`: flat storage of length `maxiter^2` reshaped on demand into
+    the `m`×`m` working copy of the Hessenberg matrix.
+"""
 mutable struct ExpvCache{T}
     mem::Vector{T}
     ExpvCache{T}(maxiter::Int) where {T} = new{T}(Vector{T}(undef, maxiter^2))
@@ -222,6 +237,28 @@ compatible_multiplicative_operand(::AbstractArray, source::AbstractArray) = sour
 
 ############################
 # Cache for phiv
+"""
+    PhivCache(w, maxiter::Int, p::Int)
+
+Reusable scratch workspace for the in-place [`phiv!`](@ref) Krylov
+matrix-phi-vector product. It packs all the intermediate buffers needed to
+evaluate `ϕ_0(tA)b … ϕ_p(tA)b` over a Krylov subspace of dimension up to
+`maxiter` into a single flat vector, whose element type matches `eltype(w)`
+(the output array `w`). Pass the cache as the `cache` keyword to `phiv!` to
+avoid reallocating these buffers on repeated calls; the buffer is grown
+automatically (via `resize!`) if a later call requests a larger subspace or
+higher order than the one it was allocated for.
+
+The `useview` type parameter records whether views into the flat buffer are
+usable (`true` for ordinary `Array`s, `false` for GPU arrays, which get freshly
+allocated reshaped copies instead).
+
+# Fields
+
+  - `mem::Vector{T}`: flat storage that is carved (by `get_caches`) into the
+    subspace vector, a Hessenberg working copy, and the two augmented matrices
+    used by the phi-function recurrence.
+"""
 mutable struct PhivCache{useview, T}
     mem::Vector{T}
 end

--- a/src/krylov_phiv_error_estimate.jl
+++ b/src/krylov_phiv_error_estimate.jl
@@ -7,6 +7,27 @@
 abstract type SubspaceCache{T} end
 abstract type HermitianSubspaceCache{T} <: SubspaceCache{T} end
 
+"""
+    StegrCache(T, n::Integer)
+
+Subspace-exponential cache for the error-estimate variant of [`expv!`](@ref)
+(the `mode = :error_estimate` path) on Hermitian operators with element type
+`T`. It is a concrete `HermitianSubspaceCache` sized for a Lanczos subspace of
+dimension up to `n`, and it drives the LAPACK symmetric-tridiagonal
+eigensolver `stegr!` to compute the exponential of the tridiagonal subspace
+matrix on each iteration. Construct one directly, or let
+[`get_subspace_cache`](@ref) build the right cache for a given
+`KrylovSubspace`.
+
+# Fields
+
+  - `v::Vector{T}`: the subspace-propagated vector (length `n`) that holds the
+    result of applying the subspace exponential.
+  - `w::Vector{T}`: scratch vector (length `n`) for intermediate values.
+  - `sw::Stegr.StegrWork{R}`: preallocated LAPACK `stegr!` workspace, where
+    `R = real(T)`, reused across iterations to diagonalize the tridiagonal
+    subspace matrix.
+"""
 mutable struct StegrCache{T, R <: Real} <: HermitianSubspaceCache{T}
     v::Vector{T} # Subspace-propagated vector
     w::Vector{T}
@@ -38,6 +59,15 @@ function expT!(
     return mul!(@view(cache.v[sel]), @view(cache.sw.Z[sel, sel]), @view(cache.w[sel]))
 end
 
+"""
+    get_subspace_cache(Ks::KrylovSubspace) -> SubspaceCache
+
+Construct the subspace-exponential cache appropriate for the Krylov subspace
+`Ks`, for use with the error-estimate variant of [`expv!`](@ref). For a real
+(Hermitian) subspace this returns a [`StegrCache`](@ref) sized to `Ks.maxiter`,
+which uses the LAPACK symmetric-tridiagonal eigensolver. Non-Hermitian
+(complex) subspaces are not yet supported and raise an error.
+"""
 function get_subspace_cache(Ks::KrylovSubspace{T, U}) where {T, U <: Complex}
     error("Subspace exponential caches not yet available for non-Hermitian matrices.")
 end


### PR DESCRIPTION
## Summary

Closes the remaining public-API documentation gaps: every exported / `public` name of `ExponentialUtilities` now has **both** a docstring for its interface **and** a rendered-docs entry.

The gap set was determined authoritatively by loading the package and checking `names(ExponentialUtilities; all=false)` against `Base.Docs.doc`, then cross-referencing the `@docs` blocks in `docs/src/`:

| Name | Before | Fix |
|------|--------|-----|
| `ExpvCache` | no docstring (had `@docs` entry) | add docstring |
| `PhivCache` | no docstring (had `@docs` entry) | add docstring |
| `StegrCache` | no docstring, no `@docs` entry | add docstring + `@docs` entry |
| `get_subspace_cache` | no docstring, no `@docs` entry | add docstring + `@docs` entry |
| `kiops` | had docstring, no `@docs` entry | add `@docs` entry |

New docstrings document each name's constructor signature, purpose, and fields/behavior, written from the actual implementation (no invented behavior). Docs entries were added to `docs/src/expv.md` (Core API for `kiops`; Caches section for `StegrCache`/`get_subspace_cache`).

### Audit false positives (no change needed)
- `exponential!` was already both documented and rendered (`docs/src/matrix_exponentials.md`).
- `StegrWork` lives in the internal `Stegr` submodule and is **not** part of `ExponentialUtilities`' public API (`isdefined(ExponentialUtilities, :StegrWork) == false`); it also already carries a docstring on its constructor.

## Validation
- Confirmed on Julia 1.12 that all five docstrings attach (`REPL.doc` non-empty for each).
- Ran a strict docs build (`warnonly = false`) locally: the five new `@docs` entries **resolve with no "docstring not found" / `docs_block` errors**. The only remaining `:missing_docs` entries are pre-existing non-public internals (`realview`, `phiv_dense(!)`, `pade_order_for_type`, `expT!`, `@diagview`, `_phi_almohy(!)`, `Stegr.StegrWork`, `stegr!`), which is why `make.jl` already carries `warnonly = [:missing_docs, :docs_block]`. That setting was **not** changed.
- Runic clean on the changed `src/` files.

No behavior changes; docs only.

Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)