### PR TITLE
exp: ExpMethodHigham2005 Padé solve via cached LinearSolve default

### DIFF
--- a/src/exp_generated/exp_1.jl
+++ b/src/exp_generated/exp_1.jl
@@ -41,7 +41,7 @@ function exp_gen!(cache, A, ::Val{1})
     memslots2 .= coeff1 .* memslots2 .+ coeff2 .* memslots4
     # Deallocating U in slot 4
     # Computing P with operation: ldiv
-    ldiv_for_generated!(memslots3, memslots1, memslots2)
+    ldiv_for_generated!(memslots3, memslots1, memslots2, cache.linsolve)
     # Deallocating Z in slot 1
     # Deallocating X in slot 2
     return copyto!(A, memslots3) # Returning P

--- a/src/exp_generated/exp_10.jl
+++ b/src/exp_generated/exp_10.jl
@@ -81,7 +81,7 @@ function exp_gen!(cache, A, ::Val{10})
     memslots2 .= coeff1 .* memslots2 .+ coeff2 .* memslots5
     # Deallocating U in slot 5
     # Computing P with operation: ldiv
-    ldiv_for_generated!(memslots3, memslots1, memslots2)
+    ldiv_for_generated!(memslots3, memslots1, memslots2, cache.linsolve)
     # Deallocating Z in slot 1
     # Deallocating X in slot 2
     # Computing S1 with operation: mult

--- a/src/exp_generated/exp_11.jl
+++ b/src/exp_generated/exp_11.jl
@@ -81,7 +81,7 @@ function exp_gen!(cache, A, ::Val{11})
     memslots2 .= coeff1 .* memslots2 .+ coeff2 .* memslots5
     # Deallocating U in slot 5
     # Computing P with operation: ldiv
-    ldiv_for_generated!(memslots3, memslots1, memslots2)
+    ldiv_for_generated!(memslots3, memslots1, memslots2, cache.linsolve)
     # Deallocating Z in slot 1
     # Deallocating X in slot 2
     # Computing S1 with operation: mult

--- a/src/exp_generated/exp_12.jl
+++ b/src/exp_generated/exp_12.jl
@@ -81,7 +81,7 @@ function exp_gen!(cache, A, ::Val{12})
     memslots2 .= coeff1 .* memslots2 .+ coeff2 .* memslots5
     # Deallocating U in slot 5
     # Computing P with operation: ldiv
-    ldiv_for_generated!(memslots3, memslots1, memslots2)
+    ldiv_for_generated!(memslots3, memslots1, memslots2, cache.linsolve)
     # Deallocating Z in slot 1
     # Deallocating X in slot 2
     # Computing S1 with operation: mult

--- a/src/exp_generated/exp_13.jl
+++ b/src/exp_generated/exp_13.jl
@@ -81,7 +81,7 @@ function exp_gen!(cache, A, ::Val{13})
     memslots2 .= coeff1 .* memslots2 .+ coeff2 .* memslots5
     # Deallocating U in slot 5
     # Computing P with operation: ldiv
-    ldiv_for_generated!(memslots3, memslots1, memslots2)
+    ldiv_for_generated!(memslots3, memslots1, memslots2, cache.linsolve)
     # Deallocating Z in slot 1
     # Deallocating X in slot 2
     # Computing S1 with operation: mult

--- a/src/exp_generated/exp_2.jl
+++ b/src/exp_generated/exp_2.jl
@@ -47,7 +47,7 @@ function exp_gen!(cache, A, ::Val{2})
     memslots2 .= coeff1 .* memslots2 .+ coeff2 .* memslots5
     # Deallocating U in slot 5
     # Computing P with operation: ldiv
-    ldiv_for_generated!(memslots3, memslots1, memslots2)
+    ldiv_for_generated!(memslots3, memslots1, memslots2, cache.linsolve)
     # Deallocating Z in slot 1
     # Deallocating X in slot 2
     return copyto!(A, memslots3) # Returning P

--- a/src/exp_generated/exp_3.jl
+++ b/src/exp_generated/exp_3.jl
@@ -53,7 +53,7 @@ function exp_gen!(cache, A, ::Val{3})
     memslots2 .= coeff1 .* memslots2 .+ coeff2 .* memslots6
     # Deallocating U in slot 6
     # Computing P with operation: ldiv
-    ldiv_for_generated!(memslots3, memslots1, memslots2)
+    ldiv_for_generated!(memslots3, memslots1, memslots2, cache.linsolve)
     # Deallocating Z in slot 1
     # Deallocating X in slot 2
     return copyto!(A, memslots3) # Returning P

--- a/src/exp_generated/exp_4.jl
+++ b/src/exp_generated/exp_4.jl
@@ -60,7 +60,7 @@ function exp_gen!(cache, A, ::Val{4})
     memslots6 .= coeff1 .* memslots6 .+ coeff2 .* memslots3
     # Deallocating U in slot 3
     # Computing P with operation: ldiv
-    ldiv_for_generated!(memslots2, memslots1, memslots6)
+    ldiv_for_generated!(memslots2, memslots1, memslots6, cache.linsolve)
     # Deallocating Z in slot 1
     # Deallocating X in slot 6
     return copyto!(A, memslots2) # Returning P

--- a/src/exp_generated/exp_5.jl
+++ b/src/exp_generated/exp_5.jl
@@ -75,7 +75,7 @@ function exp_gen!(cache, A, ::Val{5})
     memslots2 .= coeff1 .* memslots2 .+ coeff2 .* memslots5
     # Deallocating U in slot 5
     # Computing P with operation: ldiv
-    ldiv_for_generated!(memslots3, memslots1, memslots2)
+    ldiv_for_generated!(memslots3, memslots1, memslots2, cache.linsolve)
     # Deallocating Z in slot 1
     # Deallocating X in slot 2
     return copyto!(A, memslots3) # Returning P

--- a/src/exp_generated/exp_6.jl
+++ b/src/exp_generated/exp_6.jl
@@ -81,7 +81,7 @@ function exp_gen!(cache, A, ::Val{6})
     memslots2 .= coeff1 .* memslots2 .+ coeff2 .* memslots5
     # Deallocating U in slot 5
     # Computing P with operation: ldiv
-    ldiv_for_generated!(memslots3, memslots1, memslots2)
+    ldiv_for_generated!(memslots3, memslots1, memslots2, cache.linsolve)
     # Deallocating Z in slot 1
     # Deallocating X in slot 2
     # Computing S1 with operation: mult

--- a/src/exp_generated/exp_7.jl
+++ b/src/exp_generated/exp_7.jl
@@ -81,7 +81,7 @@ function exp_gen!(cache, A, ::Val{7})
     memslots2 .= coeff1 .* memslots2 .+ coeff2 .* memslots5
     # Deallocating U in slot 5
     # Computing P with operation: ldiv
-    ldiv_for_generated!(memslots3, memslots1, memslots2)
+    ldiv_for_generated!(memslots3, memslots1, memslots2, cache.linsolve)
     # Deallocating Z in slot 1
     # Deallocating X in slot 2
     # Computing S1 with operation: mult

--- a/src/exp_generated/exp_8.jl
+++ b/src/exp_generated/exp_8.jl
@@ -81,7 +81,7 @@ function exp_gen!(cache, A, ::Val{8})
     memslots2 .= coeff1 .* memslots2 .+ coeff2 .* memslots5
     # Deallocating U in slot 5
     # Computing P with operation: ldiv
-    ldiv_for_generated!(memslots3, memslots1, memslots2)
+    ldiv_for_generated!(memslots3, memslots1, memslots2, cache.linsolve)
     # Deallocating Z in slot 1
     # Deallocating X in slot 2
     # Computing S1 with operation: mult

--- a/src/exp_generated/exp_9.jl
+++ b/src/exp_generated/exp_9.jl
@@ -81,7 +81,7 @@ function exp_gen!(cache, A, ::Val{9})
     memslots2 .= coeff1 .* memslots2 .+ coeff2 .* memslots5
     # Deallocating U in slot 5
     # Computing P with operation: ldiv
-    ldiv_for_generated!(memslots3, memslots1, memslots2)
+    ldiv_for_generated!(memslots3, memslots1, memslots2, cache.linsolve)
     # Deallocating Z in slot 1
     # Deallocating X in slot 2
     # Computing S1 with operation: mult

--- a/src/exp_generated/generate_exp_code.jl
+++ b/src/exp_generated/generate_exp_code.jl
@@ -49,7 +49,7 @@ for i in 1:(size(rhov, 1) - 1)
             #line=replace(line, r"memslots(\d+)\s*.?=\s*memslots(\d+)..?memslots(\d+)" => s"LAPACK.gesv!(memslots\2, memslots\3); memslots\1=memslots\3")
             line = replace(
                 line,
-                r"memslots(\d+)\s*.?=\s*memslots(\d+)..?memslots(\d+)" => s"ldiv_for_generated!(memslots\1, memslots\2, memslots\3)"
+                r"memslots(\d+)\s*.?=\s*memslots(\d+)..?memslots(\d+)" => s"ldiv_for_generated!(memslots\1, memslots\2, memslots\3, cache.linsolve)"
             )
             # Make sure the output is in A
             line = replace(line, r"return memslots(\d+)" => s"copyto!(A,memslots\1)")

--- a/src/exp_noalloc.jl
+++ b/src/exp_noalloc.jl
@@ -11,10 +11,32 @@ ExpMethodHigham2005(A::AbstractMatrix) = ExpMethodHigham2005(A isa StridedMatrix
 ExpMethodHigham2005() = ExpMethodHigham2005(true)
 ExpMethodHigham2005(A::GPUArraysCore.AbstractGPUArray) = ExpMethodHigham2005(false)
 
+# Holds the generated-code memory slots plus, when the element type supports it,
+# a cached LinearSolve workspace for the Padé denominator solve. `getmem` sees
+# only `slots`, so the generated code is unchanged apart from passing `linsolve`.
+struct Higham2005Cache{V <: AbstractVector, L}
+    slots::V
+    linsolve::L
+end
+
+# LinearSolve's default algorithm choice with alias_A/alias_b: size-selects the
+# fastest LU (RecursiveFactorization when loaded), refactorizes in place. Only
+# for dense strided BLAS matrices; other types (GPU, BigFloat, ...) keep the
+# `lu!` fallback in `ldiv_for_generated!`.
+function _pade_linsolve(A::StridedMatrix{<:LinearAlgebra.BlasFloat})
+    Abuf = similar(A)
+    Bbuf = similar(A)
+    return LinearSolve.init(
+        LinearProblem(Abuf, Bbuf);
+        alias = LinearSolve.LinearAliasSpecifier(alias_A = true, alias_b = true)
+    )
+end
+_pade_linsolve(A) = nothing
+
 function alloc_mem(A, ::ExpMethodHigham2005)
     T = eltype(A)
     scale = T <: LinearAlgebra.BlasFloat ? similar(A, real(T), size(A, 1)) : nothing
-    return [similar(A) for i in 1:5], scale
+    return Higham2005Cache([similar(A) for i in 1:5], _pade_linsolve(A)), scale
 end
 
 # Import the generated code
@@ -32,11 +54,19 @@ include("exp_generated/exp_11.jl")
 include("exp_generated/exp_12.jl")
 include("exp_generated/exp_13.jl")
 
-function getmem(cache, k) # Called from generated code
-    return cache[k - 1]
+getmem(cache, k) = cache[k - 1] # Called from generated code
+getmem(cache::Higham2005Cache, k) = cache.slots[k - 1]
+
+# C = A \ B. Called from generated code, threading the cache's `linsolve`.
+function ldiv_for_generated!(C, A, B, linsolve) # cached LinearSolve path
+    linsolve.A = A # alias the denominator slot: factorized in place
+    linsolve.b = B
+    sol = LinearSolve.solve!(linsolve)
+    copyto!(C, sol.u)
+    return C
 end
-function ldiv_for_generated!(C, A, B) # C=A\B. Called from generated code
-    F = lu!(A) # This allocation is unavoidable, due to the interface of LinearAlgebra
+function ldiv_for_generated!(C, A, B, ::Nothing) # lu! fallback (GPU, BigFloat, ...)
+    F = lu!(A)
     ldiv!(F, B) # Result stored in B
     if (pointer_from_objref(C) != pointer_from_objref(B)) # Aliasing allowed
         copyto!(C, B)


### PR DESCRIPTION
> **Please ignore until reviewed by @ChrisRackauckas.** Draft; opened by an agent at Chris's direction.

Completes the LinearSolve migration of the package's dense solves. `ExpMethodHigham2005` is the **default** `exponential!` method, but its Padé denominator solve — inside the generated Padé code, `ldiv_for_generated!` — still used a raw `lu!(A)` with the comment *"This allocation is unavoidable, due to the interface of LinearAlgebra."* This routes it through a cached LinearSolve workspace (default algorithm + `alias_A`/`alias_b`), the same pattern `ExpMethodHigham2005Base` already uses.

**Wins (dense strided BLAS matrices):**
- **Allocation-free per call** — 0 B measured at n=100, retiring the old O(n) pivot allocation and the "unavoidable" comment.
- Size-selects the fastest LU — **RecursiveFactorization when loaded** (the common case in exponential-integrator stacks) — vs the pinned LAPACK `lu!`.
- End-to-end (RF loaded) as-fast-or-faster than master: n=30 ~−8%, n=80 ~672 vs 1000 µs, n=100 tied. Variance is high because the solve is one of several O(n³) steps.

**Scope:** GPU / BigFloat / other element types keep the exact `lu!` fallback (dispatch on a `nothing` linsolve), so behavior there is unchanged — I can't test GPU here and didn't want to risk it.

**Mechanics:** the method cache becomes a small `Higham2005Cache{slots, linsolve}` (`getmem` still sees `slots`), and the 13 generated `exp_gen!` bodies + their generator (`generate_exp_code.jl`) pass `cache.linsolve` to `ldiv_for_generated!`.

**Verified:** `exp!` ≈ `Base.exp` for n=1..200 real/complex (LinearSolve path) and BigFloat (fallback); full `basictests.jl` passes (expv/phiv/kiops/Krylov all route through `exponential!`). Requires LinearSolve 4.1 (`alias_A` in-place refactorization).

🤖 Generated with [Claude Code](https://claude.com/claude-code)