### PR TITLE
Fix GPU Higham2005 LinearSolve fallback

### DIFF
--- a/src/exp_noalloc.jl
+++ b/src/exp_noalloc.jl
@@ -24,6 +24,7 @@ end
 # for dense strided BLAS matrices; other types (GPU, BigFloat, ...) keep the
 # `lu!` fallback in `ldiv_for_generated!`.
 function _pade_linsolve(A::StridedMatrix{<:LinearAlgebra.BlasFloat})
+    A isa GPUArraysCore.AbstractGPUArray && return nothing
     Abuf = similar(A)
     Bbuf = similar(A)
     return LinearSolve.init(


### PR DESCRIPTION
This PR should be ignored until reviewed by @ChrisRackauckas.

This is separate from PR #245.

## Root cause

PR #244 moved the generated ExpMethodHigham2005 Padé denominator solve through a cached LinearSolve workspace. The code intended GPU arrays to keep the existing lu! fallback, but the GPU CI stack shows CuArray entering LinearSolve.DefaultLinearSolver and then QRFactorization, failing in cuSOLVER ldiv! with:

    DimensionMismatch: array could not be broadcast to match destination

The failing stack is from test/gpu/gputests.jl:22 through src/exp_noalloc.jl:64 and LinearSolve factorization.jl.

## Evidence

- Last passing master GPU run: https://github.com/SciML/ExponentialUtilities.jl/actions/runs/28916165607/job/85783559679 at 6edaf50.
- Passing PR #240 GPU run: https://github.com/SciML/ExponentialUtilities.jl/actions/runs/29078355346/job/86327840988 with LinearSolve v4.2.0.
- Failing PR #244 GPU run: https://github.com/SciML/ExponentialUtilities.jl/actions/runs/29079638385/job/86331307486 with the same LinearSolve v4.2.0 and the CuArray QRFactorization stack.
- Failing master GPU run: https://github.com/SciML/ExponentialUtilities.jl/actions/runs/29084368666/job/86342374555 at merge commit 9a6281c.
- PR #245 shows the same failure: https://github.com/SciML/ExponentialUtilities.jl/actions/runs/29155824483/job/86552644442.

## Change

Make _pade_linsolve return nothing for GPUArraysCore.AbstractGPUArray values even when the array also satisfies the strided BLAS matrix method, forcing the generated code back onto its intended GPU lu! fallback.

## Validation

- timeout 3600 /home/crackauc/.juliaup/bin/julia +1 --project=. -e 'using Pkg; Pkg.test()' passed: Core/basictests.jl, 673 pass, 1 broken.
- timeout 3600 /home/crackauc/.juliaup/bin/julia +1 --project=/home/crackauc/sandbox/tmp_20260708_051717_3275/repos/ExponentialUtilities-master-clean/investigation-logs/runic-env -e 'using Pkg; Pkg.add(Pkg.PackageSpec(name="Runic", version="1")); using Runic; exit(Runic.main(["--check", "."]))' passed.

Local GPU verification was not possible because this machine has no /dev/nvidia* device; the pushed draft PR is intended to let the self-hosted GPU job verify the fix.