### PR TITLE
Use SciMLTesting 2.1 in GPU tests

### DIFF
--- a/test/gpu/Project.toml
+++ b/test/gpu/Project.toml
@@ -7,5 +7,5 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 [compat]
 CUDA = "6"
 SafeTestsets = "0.1, 1"
-SciMLTesting = "1"
+SciMLTesting = "2.1"
 Test = "1"


### PR DESCRIPTION
This draft PR should be ignored until reviewed by @ChrisRackauckas.

## Summary
- update the GPU test environment SciMLTesting compat from `1` to `2.1` after the main QA compat PR merged

## Validation
- `julia +1.10 --project=. --startup-file=no -e 'using TOML; TOML.parsefile("test/gpu/Project.toml"); println("gpu project parsed")'`\n- `julia +1.10 --startup-file=no -e 'using Runic; Runic.main(ARGS)' -- --check --docstrings src test`\n- no absolute local paths found in `Project.toml`, `test/qa/Project.toml`, or `test/gpu/Project.toml`\n\nI did not run the GPU test group locally because this environment has no GPU runner attached.\n