### PR TITLE
Release prep: bump to 1.31.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ExponentialUtilities"
 uuid = "d4d017d3-3776-5f7e-afef-a10c40355c18"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "José E. Cruz Serrallés <Jose.CruzSerralles@nyulangone.org>"]
-version = "1.31.1"
+version = "1.31.2"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"


### PR DESCRIPTION
Version-bump-only release PR. Ships already-reviewed/merged PRs #240/#244/#246 (Pade denominator solve now routed through cached LinearSolve workspace instead of raw lu!/ldiv!, plus a GPU fallback fix). Mathematically equivalent algorithm, covered by existing test suite.