### PR TITLE
Safeguard Arnoldi-seeded Krylov timesteps

### DIFF
--- a/src/krylov_phiv_adaptive.jl
+++ b/src/krylov_phiv_adaptive.jl
@@ -86,9 +86,9 @@ is estimated matrix-free from the Arnoldi Hessenberg built on the first Krylov
 step, so `opnorm(A, Inf)` is never evaluated: this needs no operator method
 beyond `mul!` -- suitable for matrix types (e.g. sparse GPU arrays) that do not
 support `opnorm` -- and reflects `A`'s action on the Krylov subspace the
-exponential actually explores. In this mode the initial `tau` defaults to the
-whole interval. Pass `opnorm` as a precomputed scalar (a norm or bound) or a
-function `opnorm(A, Inf)` to override the estimate with an explicit
+exponential actually explores. The first Arnoldi step supplies the scale used
+to seed the initial `tau`. Pass `opnorm` as a precomputed scalar (a norm or
+bound) or a function `opnorm(A, Inf)` to override the estimate with an explicit
 operator-norm scale, which additionally seeds the initial `tau`.
 
 When encountering a happy breakdown in the Krylov subspace construction, the
@@ -225,15 +225,16 @@ function phiv_timestep!(
             # Matrix-free default: estimate the operator norm from the Krylov
             # Hessenberg (already the quantity the adaptation below uses), and
             # seed the initial substep from it (Niesen-Wright (17)) rather than
-            # stepping the whole interval, which matches the explicit-opnorm
-            # path's accuracy. Both are set on the first step only.
+            # stepping the whole interval. Apply the adaptation safety factor
+            # because this scale is a Krylov-subspace estimate rather than an
+            # operator-norm bound. Both are set on the first step only.
             opn = LinearAlgebra.opnorm(getH(Ks), 1)
             abstol = tol * opn
             if seed_arnoldi_tau
                 b0norm = norm(@view(B[:, 1]), Inf)
                 tau = min(
                     tend - t,
-                    10 / opn * (
+                    gamma * 10 / opn * (
                         abstol * ((m + 1) / ℯ)^(m + 1) * sqrt(2 * pi * (m + 1)) /
                             (4 * opn * b0norm)
                     )^(1 / m)

--- a/test/basictests.jl
+++ b/test/basictests.jl
@@ -573,7 +573,9 @@ end
     t = 5.0
     tol = 1.0e-7
     A = spdiagm(-1 => ones(n - 1), 0 => -2 * ones(n), 1 => ones(n - 1))
-    B = randn(n, K + 1)
+    # This input puts the first Arnoldi step just inside the adaptation acceptance
+    # boundary, so it exercises the safety factor on the estimated norm scale.
+    B = randn(Random.Xoshiro(14), n, K + 1)
     Phi_half = phi(t / 2 * A, K)
     Phi = phi(t * A, K)
     uhalf_exact = sum((t / 2)^i * Phi_half[i + 1] * B[:, i + 1] for i in 0:K)


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed

- apply the existing adaptive safety factor when the initial Krylov timestep is seeded from the Arnoldi norm estimate
- make the boundary-case regression deterministic with `Random.Xoshiro(14)`
- update the `phiv_timestep!` docstring to describe the initial-step behavior

## Why

PR #250 changed the matrix-free initial-step estimate. For the CI input, its first error estimate was narrowly accepted (`omega ≈ 1.16` with `delta = 1.2`) and the half-step relative error became `1.0152660196817718e-7`, just above the requested `1e-7` tolerance. The same safety factor already used by the adaptive controller brings that error to `6.6386e-9` without changing the test tolerance.

Bisecting identified `0d3f815` (PR #250) as the first bad commit; its parent produced a relative error of `1.5428773429973865e-8` for the same case.

## Local checks

- exact Julia 1.12.6 Core CI invocation: 676 passed, 1 pre-existing broken, 677 total
- deterministic regression before/after: `1.00753e-7` / `6.39e-9`
- 200-seed sweep: 0 failures; worst relative error `1.4357e-8`
- `julia +1.12.6 -m Runic --check --diff .`
- `git diff --check`

Please ignore this draft until it has been reviewed by @ChrisRackauckas.