### PR TITLE
Enforce rendered public API docs in QA

### DIFF
--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -2,6 +2,7 @@ using SciMLTesting, ExponentialUtilities, JET, Test
 
 run_qa(
     ExponentialUtilities;
+    api_docs_kwargs = (; rendered = true),
     explicit_imports = true,
     aqua_kwargs = (; deps_compat = (; ignore = [:libblastrampoline_jll])),
     ei_kwargs = (;


### PR DESCRIPTION
Ignore this PR until reviewed by @ChrisRackauckas.

## Summary
- enable SciMLTesting rendered public API docs QA for ExponentialUtilities
- keep the change limited to the existing QA configuration; the current package-owned exported API is already rendered in docs

## Validation
- `git diff --check`
- `Runic.main(["--check", "src", "test", "docs/make.jl"])` on Julia +1.10
- direct QA via `julia +1.10 --project=test/qa ... include("test/qa/qa.jl")`: passed, `Quality Assurance | 17 pass, 1 broken, 18 total`
- full `Pkg.test()` on Julia +1.10: passed, `Core/basictests.jl | 676 pass, 1 broken, 677 total`

Docs build note: local `docs/make.jl` reached Documenter checks, then failed on the existing external linkcheck with GitHub 429 for `https://github.com/SciML/ColPrac/blob/master/README.md`; I did not change docs settings to suppress that.

No `[sources]` or path source overrides were added.