### PR TITLE
Require Adapt 4.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -22,7 +22,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 ExponentialUtilitiesStaticArraysExt = "StaticArrays"
 
 [compat]
-Adapt = "3.4.0, 4"
+Adapt = "4.3"
 Aqua = "0.8"
 ArrayInterface = "7.1"
 DoubleFloats = "1.1.14"


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Summary

- remove the stale Adapt 3 compatibility line
- require Adapt 4.3, the first Adapt 4 release that resolves with the package's current LinearSolve and ArrayInterface constraints

This is a compatibility-only change; it does not alter package source or public API.

## Floor evidence

Adapt 4 support was added by untested CompatHelper PR #152 while retaining Adapt 3. A fresh Julia 1.10 resolver replay on this branch selected Adapt 4.3.0 as the direct-dependency floor.

I also pinned each earlier Adapt 4 release independently. Adapt 4.0.0, 4.1.0, and 4.2.0 all fail resolution: those releases restrict SciMLBase to at most 2.131.0, while the allowed LinearSolve 4.1-4.3 range requires SciMLBase 2.148.0 or newer. Therefore `Adapt = "4"` would advertise versions that cannot participate in the current dependency graph.

## Local verification

- Julia 1.10.11, deployed `julia-downgrade-compat@v2`-equivalent direct-dependency floor, locked manifest: Adapt 4.3.0
- exact-floor `Pkg.build()`: passed
- exact-floor `GROUP=Core Pkg.test(; coverage=true, allow_reresolve=false)`: 676 passed, 1 pre-existing broken, 677 total
- Julia 1.12.6 current graph: Adapt 4.7.0, ArrayInterface 7.27.0, LinearSolve 4.3.0, SciMLBase 3.36.0
- current-graph `Pkg.build()`: passed
- current-graph `GROUP=Core Pkg.test(; coverage=true, allow_reresolve=false)`: 676 passed, 1 pre-existing broken, 677 total
- current-graph `GROUP=QA Pkg.test(; coverage=true, allow_reresolve=false)`: 18 passed, 1 pre-existing broken, 19 total
- Julia Runic 1.7.0 `--check .`: passed
- `git diff --check`: passed
- TOML parse and exact `Adapt = "4.3"` assertion: passed

The existing Core suite is the regression coverage for this metadata-only change; no test was skipped, disabled, silenced, or loosened.
