### PR TITLE
Fix PhivCache being reallocated on every phiv! call

### DIFF
--- a/src/krylov_phiv.jl
+++ b/src/krylov_phiv.jl
@@ -276,7 +276,7 @@ function Base.resize!(C::PhivCache, maxiter::Int, p::Int)
 end
 function get_caches(C::PhivCache{useview, T}, m::Int, p::Int) where {useview, T}
     numelems = m + m^2 + (m + p)^2 + m * (p + 1)
-    numelems^2 > length(C.mem) && resize!(C, m, p) # resize the cache if needed
+    numelems > length(C.mem) && resize!(C, m, p) # resize the cache if needed
     e = @view(C.mem[1:m])
     offset = m
 

--- a/test/basictests.jl
+++ b/test/basictests.jl
@@ -550,6 +550,29 @@ end
     @test Q[:, 2] ≈ (t * A) \ (exp(t * A) - I) * ones(n)
 end
 
+@testset "PhivCache reuse (issue: cache reallocated every call)" begin
+    Random.seed!(0)
+    n, m, k = 40, 10, 3
+    A = randn(n, n) / 5
+    b = randn(n)
+    Ks = arnoldi(A, b; m = m)
+    w = Matrix{Float64}(undef, n, k + 1)
+    cache = ExponentialUtilities.PhivCache(b, m, k + 1)
+    phiv!(w, 0.1, Ks, k; cache = cache)
+    mem = cache.mem
+    phiv!(w, 0.1, Ks, k; cache = cache)
+    # A correctly-sized cache must not be reallocated on repeated calls
+    @test cache.mem === mem
+    # Correctness against the uncached path
+    w2 = Matrix{Float64}(undef, n, k + 1)
+    phiv!(w2, 0.1, Ks, k)
+    @test w ≈ w2
+    # An undersized cache must still grow to fit
+    smallcache = ExponentialUtilities.PhivCache(b, 2, 1)
+    phiv!(w, 0.1, Ks, k; cache = smallcache)
+    @test w ≈ w2
+end
+
 @testset "Complex Value" begin
     n = 20
     m = 10


### PR DESCRIPTION
## Summary

`get_caches(C::PhivCache, m, p)` compared `numelems^2` (instead of `numelems`) against `length(C.mem)`, so the resize branch fired on essentially every call and replaced `C.mem` with a freshly allocated buffer. This defeated the purpose of passing a `PhivCache`: every Krylov `phiv!` call — and therefore every stage of the Krylov-based exponential integrators in OrdinaryDiffEq (`ETDRK*(krylov=true)`, `Exprb*`, EPIRK/`phiv_timestep!`) — allocated a fresh workspace every step.

The analogous `ExpvCache` check (`m^2 > length`) is correct because that buffer's capacity really is `maxiter^2`; `PhivCache`'s capacity is `numelems` itself.

## Measurements (local, Julia 1.12.6)

400-dimensional non-Hermitian dense operator, `m=30`, `k=3`, preallocated cache:

- before: 124,440 bytes allocated per `phiv!` call, `cache.mem` pointer changes every call
- after: 90,128 bytes per call, `cache.mem` pointer stable

End-to-end on the Kuramoto–Sivashinsky pseudospectral benchmark problem (N=128, non-allocating nonlinearity), per-step allocations:

- `ETDRK2(krylov=true, m=20)`: 114 KB → 83 KB
- `ETDRK4(krylov=true, m=20)`: 405 KB → 295 KB
- `EPIRK4s3A`: 636 KB → 462 KB
- `Exprb43`: 506 KB → 367 KB

The remaining allocations come from the `exponential!` workspace allocated inside `phiv_dense!` on each call; that will be addressed in a follow-up PR.

## Test

Adds a regression test asserting `cache.mem` identity is preserved across calls, correctness against the uncached path, and that an undersized cache still grows.

Ran `Pkg.test()` locally: Core/basictests.jl 679 pass, 1 broken (pre-existing `@test_skip`).

---

**Note: please ignore this PR until reviewed by @ChrisRackauckas.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EDVGmmovzD5Aos3fFoPwMY