### PR TITLE
Allow LinearSolve 5

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ExponentialUtilities"
 uuid = "d4d017d3-3776-5f7e-afef-a10c40355c18"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "José E. Cruz Serrallés <Jose.CruzSerralles@nyulangone.org>"]
-version = "1.33.1"
+version = "1.33.2"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
@@ -30,7 +30,7 @@ ForwardDiff = "0.10.13, 1"
 GPUArraysCore = "0.1, 0.2"
 GenericSchur = "0.5.3"
 LinearAlgebra = "1.10"
-LinearSolve = "4.1"
+LinearSolve = "4.1, 5"
 PrecompileTools = "1"
 Printf = "1.10"
 Random = "1"


### PR DESCRIPTION
> **Please ignore this draft until it has been reviewed by @ChrisRackauckas.**

## Summary

- Allow LinearSolve 5 in addition to the existing LinearSolve 4 compatibility range.
- Bump ExponentialUtilities from 1.33.1 to 1.33.2.

## Why

NonlinearSolve 4.23 requires LinearSolve 5.0.1. OrdinaryDiffEq's nonlinear-solver stack also includes OrdinaryDiffEqLinear, whose ExponentialUtilities dependency still restricted the environment to LinearSolve 4. That made the combined environment unsatisfiable even though ExponentialUtilities' existing cached LinearSolve paths work with v5.

This is a compatibility-only prerequisite; no ExponentialUtilities implementation changes are needed.

## Validation

Run locally on Julia 1.12.6 with LinearSolve 5.0.1:

- `GROUP=Core julia +1.12 --project=. -e 'using Pkg; Pkg.test()'`: exit 0, 679 passed and 1 pre-existing broken test.
- `GROUP=QA julia +1.12 --project=. -e 'using Pkg; Pkg.test()'`: exit 0, 20 passed and 1 pre-existing broken test.
- Repository-wide Runic check: exit 0.
- `git diff --check`: exit 0.
