### PR TITLE
Krylov: stop adaptive-path allocation thrash (expcache wipe + lanczos slice copy)

### DIFF
--- a/src/arnoldi.jl
+++ b/src/arnoldi.jl
@@ -461,6 +461,6 @@ function lanczos!(
             break
         end
     end
-    @inbounds copyto!(@diagview(H, 1), v[1:(end - 1)])
+    @inbounds copyto!(@diagview(H, 1), @view(v[1:(end - 1)]))
     return Ks
 end

--- a/src/krylov_phiv.jl
+++ b/src/krylov_phiv.jl
@@ -410,9 +410,15 @@ function get_expcache!(
         nc == n && return work
     end
     work = alloc_mem(A, expmethod)::W
-    # Bound the store: adaptive Krylov can wander over many subspace sizes, and
-    # each workspace holds several n×n matrices. Resetting is cheap and rare.
-    length(entries) >= 16 && empty!(entries)
+    # Bound the store so memory stays in check, but evict only the oldest entry
+    # instead of wiping the whole cache. Adaptive Krylov revisits a modest,
+    # bounded set of extended-matrix sizes within a solve (each workspace is
+    # O((m+p)^2), tied to the subspace dimension, not the state size), so
+    # `empty!` here would repeatedly discard the still-hot workspaces and force
+    # the entire working set to be reallocated every 16th distinct size. Keeping
+    # the recently seen sizes warm makes the adaptive path allocation-free at
+    # steady state once its size set has been visited.
+    length(entries) >= 64 && popfirst!(entries)
     push!(entries, (n, work))
     return work
 end

--- a/test/basictests.jl
+++ b/test/basictests.jl
@@ -600,6 +600,30 @@ end
     @test w1 ≈ expv(0.1, Ks)
 end
 
+@testset "get_expcache! keeps workspaces across many sizes (no thrash)" begin
+    # Adaptive Krylov (phiv_timestep! with adaptive_krylov) evaluates the reduced
+    # matrix exponential at a range of extended-matrix sizes as it adapts the
+    # subspace dimension. The workspace store must keep the already-seen sizes
+    # warm; wiping it once it exceeds a small bound made the whole working set
+    # reallocate every so often, which showed up as multi-KB-per-step allocations
+    # at large state sizes. This guards that a size seen earlier is still cached
+    # after many distinct sizes have been requested (>16, the old wipe bound).
+    m = ExponentialUtilities.ExpMethodHigham2005Base()
+    cache = ExponentialUtilities.ExpvCache{Float64}(64)
+    ge!(n) = ExponentialUtilities.get_expcache!(cache, zeros(n, n), m)
+    first_work = ge!(4)
+    for n in 5:34            # 30 further distinct sizes, all past the old bound of 16
+        ge!(n)
+    end
+    # The size-4 workspace must be the very same object, not a reallocated one.
+    @test ge!(4) === first_work
+    # And a hit for an already-cached size does not allocate.
+    A4 = zeros(4, 4)
+    ge_hit() = ExponentialUtilities.get_expcache!(cache, A4, m)
+    ge_hit()
+    @test (@allocated ge_hit()) == 0
+end
+
 @testset "Complex Value" begin
     n = 20
     m = 10


### PR DESCRIPTION
## Summary

Removes the remaining per-step allocations from the adaptive Krylov path
(`phiv_timestep!` / `expv_timestep!` with `adaptive_krylov`), which the
exponential Rosenbrock integrators in OrdinaryDiffEq (Exp4/EPIRK/EXPRB) drive
every step. Two sources:

1. **`get_expcache!` cache-wipe thrash.** The exp-workspace store was reset with
   `empty!` once it held more than 16 distinct extended-matrix sizes. The
   adaptive path visits a bounded-but-varying set of subspace sizes as it adapts
   `m`; when that set exceeds 16, the wipe discarded still-hot workspaces and the
   *entire* working set (each workspace is 7 dense matrices + a `LinearSolve.init`)
   was reallocated periodically. Each workspace is `O((m+p)^2)` — tied to the
   subspace dimension, **not** the state size `n` — so keeping the seen sizes
   cached is cheap. Now evicts only the oldest entry (bound raised 16 → 64), so a
   repeat size is a hit instead of a reallocation.

2. **`lanczos!` slice copy.** `copyto!(@diagview(H, 1), v[1:(end - 1)])`
   materialized a fresh vector each call. `@view` makes it a view; source
   (sub-diagonal) and destination (super-diagonal) are disjoint, so the result is
   unchanged.

## Measured effect

Per-step allocations via the `step!` interface on a 1D semilinear
reaction–diffusion `ODEProblem`, well warmed (adaptive Krylov has settling
transients + rare spikes, so this must be measured over a long window):

| method / size      | master        | this PR              |
|--------------------|--------------:|---------------------:|
| Exp4, N=512        | ~864 B/step   | 16 B/step (median 0) |
| EPIRK4s3B, N=512   | ~32.8 KB/step | ~2.5 KB/step (median 0) |

The quiet-state per-step allocation is now **zero**; the residual amortized cost
is the occasional genuinely-new subspace size (one unavoidable `alloc_mem` +
`KrylovSubspace` `resize!` when adaptive `m` reaches a new maximum).

## Correctness

Final solutions are **bit-identical** to master (`max|Δu| = 0` across
Exp4/EPIRK4s3A/EPIRK4s3B/EXPRB53s3 on a 50-step N=256 solve). Both changes are
semantics-preserving by construction (view vs. copy of disjoint memory; the
workspace store is scratch that is fully overwritten on each use, so which sizes
are cached never affects results).

## Test

Adds a regression test: a size seen earlier must still be cached after >16
further distinct sizes are requested (the old wipe bound), and a cache hit must
not allocate. The `Core` suite passes locally.

Pairs with SciML/OrdinaryDiffEq.jl#3993 (the stepper-side `@views` slice fix);
together they take the exponential Rosenbrock steppers to zero quiet-state
per-step allocations.

---

Draft — please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
