### PR TITLE
Avoid cache-hit workspace allocations on Julia 1.10

### DIFF
--- a/src/krylov_phiv.jl
+++ b/src/krylov_phiv.jl
@@ -2,6 +2,10 @@
 
 ############################
 # Cache for expv
+mutable struct _ExponentialWorkspace{W}
+    value::W
+end
+
 """
     ExpvCache{T}(maxiter::Int)
 
@@ -39,7 +43,7 @@ mutable struct ExpvCache{T, W}
     # type -- only the instances (one per size) differ. `W === Nothing` when `T`
     # has no `alloc_mem` preallocation (e.g. BigFloat), and exponential! is then
     # called without a workspace.
-    expcache::Vector{Tuple{Int, Base.RefValue{W}}}
+    expcache::Vector{Tuple{Int, _ExponentialWorkspace{W}}}
     # First column of exp(H), copied out so the final `mul!` consumes a
     # contiguous vector rather than a column view of the reshaped `mem` buffer
     # (that view does not elide and would allocate a SubArray each call).
@@ -48,7 +52,9 @@ end
 function ExpvCache{T}(maxiter::Int) where {T}
     W = Base.promote_op(alloc_mem, Matrix{T}, typeof(ExpMethodHigham2005Base()))
     return ExpvCache{T, W}(
-        Vector{T}(undef, maxiter^2), Tuple{Int, Base.RefValue{W}}[], Vector{T}(undef, maxiter)
+        Vector{T}(undef, maxiter^2),
+        Tuple{Int, _ExponentialWorkspace{W}}[],
+        Vector{T}(undef, maxiter)
     )
 end
 function Base.resize!(C::ExpvCache{T}, maxiter::Int) where {T}
@@ -354,14 +360,14 @@ phiv!(similar(b, length(b), 3), 0.1, arnoldi(A, b), 2; cache)
   - `mem::Vector{T}`: flat storage that is carved (by `get_caches`) into the
     subspace vector, a Hessenberg working copy, and the two augmented matrices
     used by the phi-function recurrence.
-  - `expcache::Vector{Tuple{Int, W}}`: `exponential!` workspaces (see
+  - `expcache`: `exponential!` workspaces (see
     `alloc_mem`) keyed by extended-matrix size, reused across calls. `W` is a
     single concrete workspace type; see [`ExpvCache`](@ref) for why one type
     covers all sizes.
 """
 mutable struct PhivCache{useview, T, W}
     mem::Vector{T}
-    expcache::Vector{Tuple{Int, Base.RefValue{W}}}
+    expcache::Vector{Tuple{Int, _ExponentialWorkspace{W}}}
     # Reusable t^l/l! coefficient scratch for phiv_timestep! (which threads this
     # cache in). Kept here so phiv_timestep! need not allocate it per call; plain
     # phiv! does not touch it. `coeffs[1]` stays one(T); the rest are overwritten.
@@ -378,7 +384,10 @@ function PhivCache(w, maxiter::Int, p::Int)
     W = Base.promote_op(alloc_mem, Matrix{T}, typeof(ExpMethodHigham2005Base()))
     useview = !(w isa GPUArraysCore.AbstractGPUArray)
     return PhivCache{useview, T, W}(
-        mem, Tuple{Int, Base.RefValue{W}}[], ones(T, max(p, 1)), Vector{Float64}(undef, 1)
+        mem,
+        Tuple{Int, _ExponentialWorkspace{W}}[],
+        ones(T, max(p, 1)),
+        Vector{Float64}(undef, 1)
     )
 end
 
@@ -419,7 +428,7 @@ function get_expcache!(
     # the recently seen sizes warm makes the adaptive path allocation-free at
     # steady state once its size set has been visited.
     length(entries) >= 64 && popfirst!(entries)
-    workref = Base.RefValue{W}(work)
+    workref = _ExponentialWorkspace{W}(work)
     push!(entries, (n, workref))
     return workref
 end
@@ -429,7 +438,7 @@ get_expcache!(::Union{ExpvCache, PhivCache}, A, expmethod) = nothing
 # Call exponential! with the reusable workspace when one is available; the
 # two-argument form allocates its own.
 _exponential!(A, method, ::Nothing) = exponential!(A, method)
-_exponential!(A, method, work::Base.RefValue) = exponential!(A, method, work[])
+_exponential!(A, method, work::_ExponentialWorkspace) = exponential!(A, method, work.value)
 _exponential!(A, method, work) = exponential!(A, method, work)
 function Base.resize!(C::PhivCache, maxiter::Int, p::Int)
     numelems = maxiter + maxiter^2 + (maxiter + p)^2 + maxiter * (p + 1)

--- a/src/krylov_phiv.jl
+++ b/src/krylov_phiv.jl
@@ -39,7 +39,7 @@ mutable struct ExpvCache{T, W}
     # type -- only the instances (one per size) differ. `W === Nothing` when `T`
     # has no `alloc_mem` preallocation (e.g. BigFloat), and exponential! is then
     # called without a workspace.
-    expcache::Vector{Tuple{Int, W}}
+    expcache::Vector{Tuple{Int, Base.RefValue{W}}}
     # First column of exp(H), copied out so the final `mul!` consumes a
     # contiguous vector rather than a column view of the reshaped `mem` buffer
     # (that view does not elide and would allocate a SubArray each call).
@@ -48,7 +48,7 @@ end
 function ExpvCache{T}(maxiter::Int) where {T}
     W = Base.promote_op(alloc_mem, Matrix{T}, typeof(ExpMethodHigham2005Base()))
     return ExpvCache{T, W}(
-        Vector{T}(undef, maxiter^2), Tuple{Int, W}[], Vector{T}(undef, maxiter)
+        Vector{T}(undef, maxiter^2), Tuple{Int, Base.RefValue{W}}[], Vector{T}(undef, maxiter)
     )
 end
 function Base.resize!(C::ExpvCache{T}, maxiter::Int) where {T}
@@ -361,7 +361,7 @@ phiv!(similar(b, length(b), 3), 0.1, arnoldi(A, b), 2; cache)
 """
 mutable struct PhivCache{useview, T, W}
     mem::Vector{T}
-    expcache::Vector{Tuple{Int, W}}
+    expcache::Vector{Tuple{Int, Base.RefValue{W}}}
     # Reusable t^l/l! coefficient scratch for phiv_timestep! (which threads this
     # cache in). Kept here so phiv_timestep! need not allocate it per call; plain
     # phiv! does not touch it. `coeffs[1]` stays one(T); the rest are overwritten.
@@ -378,7 +378,7 @@ function PhivCache(w, maxiter::Int, p::Int)
     W = Base.promote_op(alloc_mem, Matrix{T}, typeof(ExpMethodHigham2005Base()))
     useview = !(w isa GPUArraysCore.AbstractGPUArray)
     return PhivCache{useview, T, W}(
-        mem, Tuple{Int, W}[], ones(T, max(p, 1)), Vector{Float64}(undef, 1)
+        mem, Tuple{Int, Base.RefValue{W}}[], ones(T, max(p, 1)), Vector{Float64}(undef, 1)
     )
 end
 
@@ -406,8 +406,8 @@ function get_expcache!(
     W === Nothing && return nothing  # nothing::Nothing === W, so return stays concrete
     n = size(A, 1)
     entries = C.expcache
-    for (nc, work) in entries
-        nc == n && return work
+    for (nc, workref) in entries
+        nc == n && return workref
     end
     work = alloc_mem(A, expmethod)::W
     # Bound the store so memory stays in check, but evict only the oldest entry
@@ -419,8 +419,9 @@ function get_expcache!(
     # the recently seen sizes warm makes the adaptive path allocation-free at
     # steady state once its size set has been visited.
     length(entries) >= 64 && popfirst!(entries)
-    push!(entries, (n, work))
-    return work
+    workref = Base.RefValue{W}(work)
+    push!(entries, (n, workref))
+    return workref
 end
 # Non-default methods are not cached; the caller allocates via two-arg exponential!.
 get_expcache!(::Union{ExpvCache, PhivCache}, A, expmethod) = nothing
@@ -428,6 +429,7 @@ get_expcache!(::Union{ExpvCache, PhivCache}, A, expmethod) = nothing
 # Call exponential! with the reusable workspace when one is available; the
 # two-argument form allocates its own.
 _exponential!(A, method, ::Nothing) = exponential!(A, method)
+_exponential!(A, method, work::Base.RefValue) = exponential!(A, method, work[])
 _exponential!(A, method, work) = exponential!(A, method, work)
 function Base.resize!(C::PhivCache, maxiter::Int, p::Int)
     numelems = maxiter + maxiter^2 + (maxiter + p)^2 + maxiter * (p + 1)


### PR DESCRIPTION
Stores the large `exponential!` workspace in a private concrete `_ExponentialWorkspace{W}` cell, rather than returning it by value from the cache. This removes the 64-byte Julia 1.10 allocation on warmed `get_expcache!` hits while using only ExponentialUtilities-owned APIs.

The old return-by-value path regressed at commit `3d1e43f`; released `e044eeb` fails the Core allocation assertion on Julia LTS hosted platforms and in the downgrade job. The initial draft used non-public `Base.RefValue`; this update replaces it with the local cell so ExplicitImports passes.

Validation:
- Julia 1.10 direct cache controls: concrete local cell, cache identity reuse, and zero warmed-hit allocations.
- Julia 1.10 non-Hermitian Complex `ExpvCache` control: workspace reuse confirmed.
- Julia 1.10 `GROUP=Core Pkg.test(; coverage=true)`: 738 passed, 1 expected broken, 0 failures/errors.
- Julia 1.10 `GROUP=QA Pkg.test(; coverage=true)`: 19 passed, 2 expected broken, 0 failures/errors; ExplicitImports passes.
- Runic check and `git diff --check` pass.

Draft — please ignore until reviewed by @ChrisRackauckas.