### PR TITLE
Assert the StaticArrays extension actually loaded in QA

### DIFF
--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -6,6 +6,14 @@ using AllocCheck: check_allocs
 # StaticArrays here is what puts ExponentialUtilitiesStaticArraysExt under QA.
 using StaticArrays
 
+# ExplicitImports silently skips an extension that fails to load, so assert the
+# extension modules actually exist rather than trusting a green run_qa.
+@testset "Extensions loaded" begin
+    @test Base.get_extension(
+        ExponentialUtilities, :ExponentialUtilitiesStaticArraysExt
+    ) !== nothing
+end
+
 run_qa(
     ExponentialUtilities;
     ei_kwargs = (;


### PR DESCRIPTION
Follow-up to #263, which was merged before this guard was pushed.

## Why

The extension scan that #263 turned on can be silently lost again.
ExplicitImports skips an extension whose module does not exist:

```julia
ext_mod = Base.get_extension(mod, Symbol(ext))
ext_mod === nothing && continue
```

That skip is silent — every check then reports a clean pass. So if a future
change breaks `ExponentialUtilitiesStaticArraysExt`'s precompilation, or the
`using StaticArrays` line in `test/qa/qa.jl` gets dropped, QA goes green while
extension coverage quietly falls back to zero, which is exactly the state #263
just fixed.

## What changed

Assert the extension module exists rather than trusting a green `run_qa`:

```julia
@testset "Extensions loaded" begin
    @test Base.get_extension(
        ExponentialUtilities, :ExponentialUtilitiesStaticArraysExt
    ) !== nothing
end
```

Verified locally that this actually discriminates rather than being vacuously
true: in a session with only `using ExponentialUtilities`, `Base.get_extension`
returns `nothing`; after `using StaticArrays` it returns the module.

## Local verification

`GROUP=QA julia --project=. -e 'using Pkg; Pkg.test()'` on this branch:

```
Test Summary: | Pass  Broken  Total     Time
QA/qa.jl      |   22       2     24  3m30.7s
     Testing ExponentialUtilities tests passed
```

That is 22 passing versus 21 on master, the difference being the new guard. The
2 broken are the pre-existing `broken = true` markers in the AllocCheck testset,
untouched here. No package source is changed by this PR, only `test/qa/qa.jl`.

---

Please ignore this PR until it has been reviewed by @ChrisRackauckas.
