### PR TITLE
Promote alloc_mem to a documented public API

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ExponentialUtilities"
 uuid = "d4d017d3-3776-5f7e-afef-a10c40355c18"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "José E. Cruz Serrallés <Jose.CruzSerralles@nyulangone.org>"]
-version = "1.33.4"
+version = "1.34.0"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
@@ -12,6 +12,7 @@ LinearSolve = "7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+SciMLPublic = "431bcebd-1456-4ced-9d72-93c2757fff0b"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [weakdeps]
@@ -35,6 +36,7 @@ Printf = "1.10"
 Random = "1"
 SafeTestsets = "0.1, 1"
 SciMLTesting = "2.4"
+SciMLPublic = "1"
 SparseArrays = "1.10"
 StaticArrays = "1.9.8"
 Test = "1"

--- a/docs/src/matrix_exponentials.md
+++ b/docs/src/matrix_exponentials.md
@@ -17,7 +17,7 @@ ExpMethodNative
 ExpMethodDiagonalization
 ```
 
-## Utilities
+## Workspace API
 
 ```@docs
 ExponentialUtilities.alloc_mem

--- a/src/ExponentialUtilities.jl
+++ b/src/ExponentialUtilities.jl
@@ -14,6 +14,7 @@ import PrecompileTools: @compile_workload, @setup_workload
 import GenericSchur
 import GPUArraysCore
 import Adapt
+import SciMLPublic: @public
 
 const BlasFloat = Union{Float32, Float64, ComplexF32, ComplexF64}
 
@@ -67,5 +68,7 @@ export phi, phi!, KrylovSubspace, arnoldi, arnoldi!, lanczos!, ExpvCache, PhivCa
 export ExpMethodHigham2005,
     ExpMethodHigham2005Base, ExpMethodGeneric, ExpMethodNative,
     ExpMethodDiagonalization
+
+@public alloc_mem
 
 end

--- a/src/exp.jl
+++ b/src/exp.jl
@@ -2,9 +2,43 @@
 
 # Fallback
 """
-    cache = alloc_mem(A, method)
+    alloc_mem(A, method)
 
-Pre-allocates memory associated with matrix exponential function `method` and matrix `A`. To be used in combination with [`exponential!`](@ref).
+Allocate reusable workspace for [`exponential!`](@ref).
+
+`alloc_mem` is the public allocation hook for matrix-exponential methods. Method
+implementations may specialize it together with `exponential!(A, method, cache)`
+to separate workspace allocation from repeated evaluations. Treat the returned
+cache as opaque and pass it back only for inputs compatible with the prototype
+`A` and the same method configuration.
+
+# Arguments
+
+  - `A`: prototype input that determines the workspace's shape, element type,
+    storage type, and execution device.
+  - `method`: matrix-exponential method whose workspace should be allocated.
+
+# Returns
+
+A method-specific cache accepted as the third argument to `exponential!`, or
+`nothing` when `method` does not require reusable workspace.
+
+# Examples
+
+```jldoctest
+julia> using ExponentialUtilities, LinearAlgebra
+
+julia> A = [0.0 1.0; -1.0 0.0];
+
+julia> reference = exp(A);
+
+julia> method = ExpMethodHigham2005();
+
+julia> cache = ExponentialUtilities.alloc_mem(A, method);
+
+julia> exponential!(A, method, cache) ≈ reference
+true
+```
 """
 function alloc_mem(A, method)
     return nothing

--- a/test/basictests.jl
+++ b/test/basictests.jl
@@ -4,6 +4,27 @@ using ExponentialUtilities: getH, getV, exponential!, ExpMethodNative,
     ExpMethodHigham2005Base, alloc_mem
 using ForwardDiff, StaticArrays, DoubleFloats
 
+@testset "alloc_mem public API" begin
+    A = randn(3, 3)
+    @test ExponentialUtilities.alloc_mem(A, ExpMethodGeneric()) === nothing
+
+    @static if isdefined(Base.Docs, :hasdoc)
+        @test Base.Docs.hasdoc(ExponentialUtilities, :alloc_mem)
+    else
+        @test Base.Docs.doc(ExponentialUtilities, :alloc_mem) !== nothing
+    end
+
+    @static if isdefined(Base, :isexported)
+        @test !Base.isexported(ExponentialUtilities, :alloc_mem)
+    else
+        @test :alloc_mem ∉ names(ExponentialUtilities)
+    end
+
+    @static if VERSION >= v"1.11.0-DEV.469"
+        @test Base.ispublic(ExponentialUtilities, :alloc_mem)
+    end
+end
+
 @testset "exp!" begin
     n = 100
     A1 = randn(n, n)
@@ -28,7 +49,7 @@ using ForwardDiff, StaticArrays, DoubleFloats
 
             # With preallocation
             mem = alloc_mem(A1, m)
-            E1 = exponential!(copy(A1), m)
+            E1 = exponential!(copy(A1), m, mem)
             @test E1 ≈ expA1
         end
     end

--- a/test/basictests.jl
+++ b/test/basictests.jl
@@ -5,7 +5,7 @@ using ExponentialUtilities: getH, getV, exponential!, ExpMethodNative,
 using ForwardDiff, StaticArrays, DoubleFloats
 
 @testset "alloc_mem public API" begin
-    A = randn(3, 3)
+    A = [1.0 0.0; 0.0 1.0]
     @test ExponentialUtilities.alloc_mem(A, ExpMethodGeneric()) === nothing
 
     @static if isdefined(Base.Docs, :hasdoc)


### PR DESCRIPTION
Ignore until reviewed by @ChrisRackauckas.

## Summary

- declare the existing `alloc_mem` workspace hook public through SciMLPublic
- document its prototype, opaque-cache contract, extension rule, return value, and executable usage
- render it under the workspace API and test the generic fallback and cache-consuming path
- bump the package minor version because this adds public API

## Motivation

`alloc_mem` is already the allocation hook paired with `exponential!` and is used by downstream solver packages, but it was not declared public. Downstreams should be able to rely on the owner-declared API instead of carrying ExplicitImports exceptions.

## Validation

- Julia 1.10 `Pkg.test()`: 741 passed, 1 pre-existing broken
- Julia 1.10 package QA: 19/19 passed; extension QA: 1/1 passed
- Julia release package QA: 21/21 passed; extension QA: 1/1 passed
- Julia 1.10 Documenter build passed, including doctests
- targeted public API tests passed on Julia 1.10 and release
- Runic 1.7.0 and `git diff --check` passed