### PR TITLE
Set ExponentialUtilities version to 1.35.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ExponentialUtilities"
 uuid = "d4d017d3-3776-5f7e-afef-a10c40355c18"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "José E. Cruz Serrallés <Jose.CruzSerralles@nyulangone.org>"]
-version = "1.34.0"
+version = "1.35.0"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

Correct the package version declarations to the first sequential patch or minor release after General's latest non-yanked versions. The default branch contains source changes, but this PR is limited to release metadata and internal compat needed by the sequential versions.

| Package | General | Branch before | Proposed | Bump |
|---|---:|---:|---:|---|
| ExponentialUtilities | 1.34.0 | 1.34.0 | 1.35.0 | minor |

## Verification

- `GROUP=QA /home/crackauc/.juliaup/bin/julia +release --project=. -e 'using Pkg; Pkg.test()'` — passed. `Test Summary: | Pass  Broken  Total     Time / QA/qa.jl      |   28       2     30  3m39.9s / Testing ExponentialUtilities tests passed`
- `/home/crackauc/.juliaup/bin/julia +release --project=. -e 'using Pkg; Pkg.test()'` — passed. `Test Summary:      | Pass  Broken  Total     Time / Core/basictests.jl |  742       1    743  4m54.0s / Testing ExponentialUtilities tests passed`
- `/home/crackauc/.juliaup/bin/julia +release --startup-file=no -m Runic --check .` — passed.
- `typos --force-exclude Project.toml` — passed.
- `git diff --check` — passed.

The docs build was not run because this diff changes no docstrings, documentation, or public API. GPU and downstream jobs were not run locally.

## Registration

After this PR is merged, register each package separately from a commit on the default branch:

- ExponentialUtilities: `@JuliaRegistrator register`