### PR TITLE
Pass correct off-diagonal length to `SymTridiagonal` in `expT!` call

### DIFF
--- a/src/krylov_phiv_error_estimate.jl
+++ b/src/krylov_phiv_error_estimate.jl
@@ -188,7 +188,7 @@ function expv!(
 
     for j in 1:m
         lanczos_step!(j, A, V, α, β)
-        expT!(@view(α[1:j]), @view(β[1:j]), t, cache)
+        expT!(@view(α[1:j]), @view(β[1:(j - 1)]), t, cache)
 
         # This is practical error estimate Er₂ from
         #


### PR DESCRIPTION
The Lanczos loop in the error-estimate variant of `expv!` passes `@view(β[1:j])` to `expT!`, one element more than the `j×j` tridiagonal needs — `β[j]` is the residual norm, not part of `T_j`. `SymTridiagonal` used to ignore the extra element (LAPACK convention), but on Julia 1.14 it throws `DimensionMismatch` (JuliaLang/LinearAlgebra.jl#1569), which currently breaks dependents in PkgEval at precompile time, e.g. [FirstPassageTools](https://pkgeval.s3.us-east-2.amazonaws.com/runs/gh-5428371050/logs/primary/FirstPassageTools.log) and [MRFingerprintingRecon](https://pkgeval.s3.us-east-2.amazonaws.com/runs/gh-5428371050/logs/primary/MRFingerprintingRecon.log).

Passing `β[1:j-1]` is accepted on all Julia versions (no compat bound changes needed, safe to backport), and `expT!` only uses `β` through the `SymTridiagonal`, so behavior on ≤1.13 is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)