### PR TITLE
Use non-mutating `eigen` in `expT!` to avoid corrupting the Lanczos diagonal

### DIFF
--- a/src/krylov_phiv_error_estimate.jl
+++ b/src/krylov_phiv_error_estimate.jl
@@ -59,7 +59,7 @@ function expT!(
         α::AbstractVector{R}, β::AbstractVector{R}, t::Number,
         cache::StegrCache{T, R}
     ) where {T, R <: Real}
-    F = eigen!(SymTridiagonal(α, β))
+    F = eigen(SymTridiagonal(α, β))
     sel = 1:length(α)
     @inbounds for i in sel
         cache.w[i] = exp(t * F.values[i]) * F.vectors[1, i]

--- a/test/basictests.jl
+++ b/test/basictests.jl
@@ -766,10 +766,12 @@ end
     w = expv(-im, dt * A, b, m = m, tol = atol, rtol = rtol, mode = :error_estimate)
 
     function fullexp(A, v)
-        w = similar(v)
+        # a distinct name: assigning to `w` here would capture and overwrite
+        # the testset-local `w` above, making the comparison below vacuous
+        wfull = similar(v)
         eA = exp(A)
-        mul!(w, eA, v)
-        w
+        mul!(wfull, eA, v)
+        wfull
     end
 
     w′ = fullexp(-im * dt * A, b)


### PR DESCRIPTION
Since v1.34.0, `expT!` calls `eigen!(SymTridiagonal(α, β))` where `α` is a view into `Ks.H`. LAPACK's `stegr!` overwrites its diagonal input, so each call corrupts `α[1:j]` — every subsequent Lanczos iteration in the error-estimate variant of `expv!` then diagonalizes garbage, giving wrong results and spurious early termination on all Julia versions. The pre-#258 workspace path was unaffected because it copied first (`copyto!(sw.dv, α)`); #258 replaced it with the mutating `eigen!`. Using non-mutating `eigen` restores correctness.

Evidence (Julia 1.12, seeded n=300 Hermitian, the "Alternative Lanczos expv Interface" setup, error vs dense `exp`):

| version | error | checksum of result |
|---|---|---|
| v1.33.0 (last before #258) | 5.1e-11 | `-19.894705577535643 - 210.2630548621702im` |
| current master | **13.0** (stops after 3 iterations) | `-18.6848732770996 - 210.70186885565363im` |
| this PR | 5.1e-11 | bit-identical to v1.33.0 |

**Why CI never caught this:** the "Alternative Lanczos expv Interface" testset is vacuous. Inside the testset (a local scope), the inner function

```julia
function fullexp(A, v)
    w = similar(v)
    ...
```

does not create a local `w` — it captures and **overwrites the testset-local `w` holding the `expv` result**. `δw = norm(w - w′)` then compares the dense exponential with itself (`w === w′`), so `δw` is exactly `0.0` no matter how wrong `expv` is. The second commit renames the inner variable so the test actually checks the Krylov result; with the fix here the honest testset passes (and it fails against current master, err ≈ 13 vs the 1e-10 tolerance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)