### PR TITLE
Diagonalize the Lanczos subspace matrix without allocating

### DIFF
--- a/src/krylov_phiv_error_estimate.jl
+++ b/src/krylov_phiv_error_estimate.jl
@@ -13,9 +13,9 @@ abstract type HermitianSubspaceCache{T} <: SubspaceCache{T} end
 Subspace-exponential cache for the error-estimate variant of [`expv!`](@ref)
 (the `mode = :error_estimate` path) on Hermitian operators with element type
 `T`. It is a concrete `HermitianSubspaceCache` sized for a Lanczos subspace of
-dimension up to `n`, and it uses the symmetric-tridiagonal eigensolver to
-compute the exponential of the tridiagonal subspace matrix on each iteration.
-Construct one directly, or let
+dimension up to `n`. Every iteration diagonalizes the tridiagonal subspace
+matrix with a preallocated implicit-QL eigensolver, so applying the subspace
+exponential allocates nothing. Construct one directly, or let
 [`get_subspace_cache`](@ref) build the right cache for a given
 `KrylovSubspace`.
 
@@ -33,6 +33,10 @@ A `StegrCache` sized for subspaces through dimension `n`.
   - `v::Vector{T}`: the subspace-propagated vector (length `n`) that holds the
     result of applying the subspace exponential.
   - `w::Vector{T}`: scratch vector (length `n`) for intermediate values.
+  - `d::Vector{R}`, `e::Vector{R}`: working copies (length `n`) of the
+    tridiagonal diagonal and off-diagonal, overwritten by the eigensolver, where
+    `R = real(T)`.
+  - `Z::Matrix{R}`: `n × n` eigenvector workspace.
 
 # Examples
 
@@ -43,9 +47,86 @@ cache = StegrCache(ComplexF64, 30)
 mutable struct StegrCache{T, R <: Real} <: HermitianSubspaceCache{T}
     v::Vector{T} # Subspace-propagated vector
     w::Vector{T}
+    d::Vector{R}
+    e::Vector{R}
+    Z::Matrix{R}
     function StegrCache(::Type{T}, n::Integer) where {T}
-        return new{T, real(T)}(Vector{T}(undef, n), Vector{T}(undef, n))
+        R = real(T)
+        return new{T, R}(
+            Vector{T}(undef, n), Vector{T}(undef, n),
+            Vector{R}(undef, n), Vector{R}(undef, n), Matrix{R}(undef, n, n)
+        )
     end
+end
+
+"""
+    symtridiag_eigen!(d, e, Z)
+
+Diagonalize the real symmetric tridiagonal matrix with diagonal `d` and
+off-diagonal `e` (`e[i]` couples rows `i` and `i + 1`; `e[end]` is scratch)
+by implicit QL iteration with Wilkinson shifts. On return `d` holds the
+eigenvalues, in no particular order, and `Z` holds the corresponding
+eigenvectors in its columns, provided `Z` was the identity on entry. The
+rotations are accumulated into whatever `Z` contains, so passing a
+non-identity `Z` yields `Z * Q`. Works in place on the given buffers and
+allocates nothing.
+"""
+function symtridiag_eigen!(
+        d::AbstractVector{R}, e::AbstractVector{R}, Z::AbstractMatrix{R}
+    ) where {R <: Real}
+    n = length(d)
+    n == 0 && return d, Z
+    @inbounds e[n] = zero(R)
+    @inbounds for l in 1:n
+        iter = 0
+        while true
+            m = l
+            while m < n
+                abs(e[m]) <= eps(R) * (abs(d[m]) + abs(d[m + 1])) && break
+                m += 1
+            end
+            m == l && break
+            (iter += 1) > 30n && error("symtridiag_eigen!: no convergence after 30n QL iterations")
+            g = (d[l + 1] - d[l]) / (2 * e[l])
+            r = hypot(g, one(R))
+            g = d[m] - d[l] + e[l] / (g + copysign(r, g))
+            s = one(R)
+            c = one(R)
+            p = zero(R)
+            underflow = false
+            i = m - 1
+            while i >= l
+                f = s * e[i]
+                b = c * e[i]
+                r = hypot(f, g)
+                e[i + 1] = r
+                if iszero(r)
+                    d[i + 1] -= p
+                    e[m] = zero(R)
+                    underflow = true
+                    break
+                end
+                s = f / r
+                c = g / r
+                g = d[i + 1] - p
+                r = (d[i] - g) * s + 2 * c * b
+                p = s * r
+                d[i + 1] = g + p
+                g = c * r - b
+                for k in 1:n
+                    zk = Z[k, i + 1]
+                    Z[k, i + 1] = s * Z[k, i] + c * zk
+                    Z[k, i] = c * Z[k, i] - s * zk
+                end
+                i -= 1
+            end
+            underflow && continue
+            d[l] -= p
+            e[l] = g
+            e[m] = zero(R)
+        end
+    end
+    return d, Z
 end
 
 """
@@ -53,18 +134,28 @@ end
 
 Calculate the subspace exponential `exp(t*T)` for a tridiagonal
 subspace matrix `T` with `α` on the diagonal and `β` on the
-super-/subdiagonal.
+super-/subdiagonal. `α` and `β` are copied into the cache first and are not
+modified.
 """
 function expT!(
         α::AbstractVector{R}, β::AbstractVector{R}, t::Number,
         cache::StegrCache{T, R}
     ) where {T, R <: Real}
-    F = eigen(SymTridiagonal(α, β))
     sel = 1:length(α)
+    d = @view cache.d[sel]
+    e = @view cache.e[sel]
+    Z = @view cache.Z[sel, sel]
+    copyto!(d, α)
+    copyto!(e, β)
+    fill!(Z, zero(R))
     @inbounds for i in sel
-        cache.w[i] = exp(t * F.values[i]) * F.vectors[1, i]
+        Z[i, i] = one(R)
     end
-    return mul!(@view(cache.v[sel]), @view(F.vectors[sel, sel]), @view(cache.w[sel]))
+    symtridiag_eigen!(d, e, Z)
+    @inbounds for i in sel
+        cache.w[i] = exp(t * d[i]) * Z[1, i]
+    end
+    return mul!(@view(cache.v[sel]), Z, @view(cache.w[sel]))
 end
 
 """
@@ -73,7 +164,8 @@ end
 Construct the subspace-exponential cache appropriate for the Krylov subspace
 `Ks`, for use with the error-estimate variant of [`expv!`](@ref). For a real
 (Hermitian) subspace this returns a [`StegrCache`](@ref) sized to `Ks.maxiter`,
-which uses a symmetric-tridiagonal eigensolver. Non-Hermitian
+which diagonalizes the tridiagonal subspace matrix with a preallocated
+implicit-QL eigensolver. Non-Hermitian
 (complex) subspaces are not yet supported and raise an error.
 
 # Arguments

--- a/src/krylov_phiv_error_estimate.jl
+++ b/src/krylov_phiv_error_estimate.jl
@@ -70,6 +70,11 @@ eigenvectors in its columns, provided `Z` was the identity on entry. The
 rotations are accumulated into whatever `Z` contains, so passing a
 non-identity `Z` yields `Z * Q`. Works in place on the given buffers and
 allocates nothing.
+
+Accumulating the rotations costs `O(n^3)`, against `O(n^2)` for LAPACK's MRRR
+(`stegr!`). It is nonetheless the faster choice on the Lanczos tridiagonals this
+path produces, whose decaying off-diagonals deflate in few sweeps; on generic
+tridiagonals it falls behind LAPACK past `n` of roughly 130.
 """
 function symtridiag_eigen!(
         d::AbstractVector{R}, e::AbstractVector{R}, Z::AbstractMatrix{R}

--- a/test/basictests.jl
+++ b/test/basictests.jl
@@ -785,6 +785,69 @@ end
     @test norm(wz) == 0
 end
 
+@testset "Preallocated symmetric tridiagonal eigensolver" begin
+    using ExponentialUtilities: StegrCache, expT!, symtridiag_eigen!
+
+    function tridiag_case(R, n)
+        α = randn(R, n)
+        β = randn(R, n)
+        return α, β, SymTridiagonal(α, β[1:(n - 1)])
+    end
+
+    # measured inside functions so the calls are statically dispatched; at
+    # testset scope the loop variables are boxed and the dispatch itself allocates
+    alloc_eigen(d, e, Z) = @allocated symtridiag_eigen!(d, e, Z)
+    alloc_expT(α, β, t, cache) = @allocated expT!(α, β, t, cache)
+
+    Random.seed!(5)
+    @testset "matches eigen ($R, n=$n)" for R in (Float64, Float32), n in (1, 2, 3, 7, 30)
+        α, β, T = tridiag_case(R, n)
+        d = copy(α)
+        e = copy(β)
+        Z = Matrix{R}(I, n, n)
+        symtridiag_eigen!(d, e, Z)
+        @test sort(d) ≈ eigvals(T)
+        @test Z' * Z ≈ I
+        @test Z * Diagonal(d) * Z' ≈ Matrix(T)
+        @test alloc_eigen(d, e, Z) == 0
+    end
+
+    @testset "degenerate matrices" begin
+        # already diagonal, and clusters of equal eigenvalues
+        for T in (
+                SymTridiagonal([1.0, 2.0, 3.0], [0.0, 0.0]),
+                SymTridiagonal(fill(2.0, 5), zeros(4)),
+                SymTridiagonal([1.0, 1.0, 1.0, 1.0], [1.0, 0.0, 1.0]),
+            )
+            n = size(T, 1)
+            d = copy(T.dv)
+            e = vcat(T.ev, 0.0)
+            Z = Matrix{Float64}(I, n, n)
+            symtridiag_eigen!(d, e, Z)
+            @test sort(d) ≈ eigvals(T)
+            @test Z * Diagonal(d) * Z' ≈ Matrix(T)
+        end
+    end
+
+    @testset "expT! ($T)" for T in (Float64, ComplexF64, Float32, ComplexF32)
+        R = real(T)
+        n = 30
+        cache = StegrCache(T, n)
+        t = T <: Complex ? -im * R(0.7) : R(0.7)
+        for j in (1, 2, 5, 13, n)
+            α, β, Tj = tridiag_case(R, j)
+            α0, β0 = copy(α), copy(β)
+            expT!(α, β, t, cache)
+            @test α == α0
+            @test β == β0
+            ref = exp(t * Matrix(Tj))[:, 1]
+            @test cache.v[1:j] ≈ ref rtol = 100 * eps(R) * j
+        end
+        α, β, _ = tridiag_case(R, n)
+        @test alloc_expT(α, β, t, cache) == 0
+    end
+end
+
 module ExternalMatrixFreeOperator
     using LinearAlgebra
     export Operator


### PR DESCRIPTION
> **Ignore until reviewed by @ChrisRackauckas.**

`expT!` copies `α`/`β` into buffers held by `StegrCache` and diagonalizes them with a pure-Julia implicit-QL (Wilkinson-shift) eigensolver, `symtridiag_eigen!`, so every iteration of the error-estimate `expv!` allocates nothing. `StegrCache` gains three real workspace fields (`d`, `e`, `Z`); its constructor signature and the public API are unchanged.

This also fixes master's currently-red `QA (julia 1)` job. Since #278 that job fails ExplicitImports' `no_implicit_imports` on `eigen`; this PR removes the `eigen` call entirely. With #280 merged, QA is the only failing job left on master (https://github.com/SciML/ExponentialUtilities.jl/actions/runs/34133265541).

**Why not a preallocated LAPACK call:** the pre-#258 `StegrWork` path went through `@blasfunc`/`BlasInt`/`ccall`, and none of `LAPACK.stegr!`, `LAPACK.steqr!`, `LinearAlgebra.BlasInt`, `BLAS.@blasfunc`, or `USE_BLAS64` are `public` (`Base.ispublic` is `false` for all of them on 1.12), so strict QA removed it. A 30x30 tridiagonal QL is about 60 lines and works on cache buffers.

## Performance

Measured against the **preallocated** LAPACK path (v1.33.0's `StegrWork` `ccall` into `dstegr_` with a reused workspace), so both sides allocate zero bytes and the comparison is algorithm to algorithm. Julia 1.12.7, single-threaded BLAS, `@belapsed` medians, at the default subspace size 30:

| tridiagonal | QL (this PR) | preallocated LAPACK `stegr!` | allocating `eigen` (master) |
|---|---|---|---|
| random | 65 µs | 98 µs | 101 µs (16.7 kB) |
| Lanczos-generated | 53 µs | 109 µs | 112 µs (16.7 kB) |

The allocations `eigen` adds cost bytes but little time, about 3 µs at n = 100. The real gap is algorithmic, and it runs against the asymptotics: MRRR is `O(n^2)` where accumulating QL rotations is `O(n^3)`. LAPACK does win on generic tridiagonals past n of roughly 130, but not on the matrices this path actually produces, whose decaying off-diagonals and clustered Ritz values deflate in few QL sweeps and deepen MRRR's representation tree:

| n | random, QL/LAPACK | Lanczos, QL/LAPACK |
|---|---|---|
| 30 | 0.66x | 0.51x |
| 100 | 0.85x | 0.43x |
| 150 | 1.12x | 0.46x |
| 300 | 1.34x | 0.55x |
| 400 | 1.60x | 0.65x |

The docstring records that crossover so nobody raises `maxiter` into the losing regime unaware.

End to end against v1.33.0, the last release that still had the preallocated LAPACK path, `atol = rtol = 1e-12`, both at zero bytes on the dense case and agreeing to 12 digits:

| version | dense Hermitian n=300 | sparse Laplacian n=1e5 |
|---|---|---|
| v1.33.0 (preallocated LAPACK) | 1863 µs | 15305 µs |
| this PR (QL) | 1713 µs | 15159 µs |

So this is not only recovering what #258 lost; it is about 8% faster than the best the package has ever been on the dense case, and level where the matrix-vector product dominates.

## Allocation

Julia 1.12.7, seeded n = 300 Hermitian problem, measured inside a compiled caller:

```
=== master ===
  Ks.m=18  rel.err=4.0709797267623655e-13
  bytes per expv! call (n=300, m=30): 75072
  bytes per expT! call (j=30):        16072
=== this branch ===
  Ks.m=18  rel.err=4.069943031816314e-13
  bytes per expv! call (n=300, m=30): 0
  bytes per expT! call (j=30):        0
```

## Tests

New `Preallocated symmetric tridiagonal eigensolver` testset: eigenvalues match `eigvals`, `Z` is orthogonal and reconstructs the matrix, degenerate/diagonal/clustered cases, `expT!` matches dense `exp` for all four element types without mutating `α`/`β`, and `@allocated == 0` for both `symtridiag_eigen!` and `expT!`. The allocation assertions are the discriminating tests: on master `expT!` allocates 16072 bytes, and `symtridiag_eigen!` does not exist. Accuracy against `eigvals` is 1e-15 relative across sizes 5 to 200.

Local runs on f106365, rebased onto master a65c39a (Julia 1.12.7, all exit 0):

```
GROUP=Core   Core/basictests.jl |  852       1    853  4m20.9s
GROUP=QA     QA/qa.jl           |   28       2     30  3m05.9s   <- no errors; master has 1
docs/make.jl                    no errors
Runic --check / typos           clean
```

**Not verified:** GPU group (needs CUDA), the new 32-bit lane from #282, downstream, `julia pre` locally. GPU behaviour is unchanged by construction: `Ks.H` is always a host `Matrix`, so `expT!` never touches device memory. I confirmed with JLArrays that a device-resident `KrylovSubspace` gives identical results on master and this branch, and that the `expv(...; mode = :error_estimate)` convenience wrapper scalar-indexes on both (pre-existing, `_expv_ee` always builds a host subspace).

**Reviewer attention:** this replaces a vendored LAPACK routine with in-tree numerical code the package now maintains. The convergence bound is 30n QL sweeps per eigenvalue, mirroring LAPACK `steqr`; hitting it throws. Eigenvalues come back unsorted, which `expT!` does not need.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoGUEUrLDsXQjfRRTvYdya
