### PR TITLE
Work around Julia 1.12 miscompile of static Padé products

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,35 @@
+# Agent notes for ExponentialUtilities.jl
+
+## Validation before pushing
+
+- Format: `julia --project=@runic -m Runic --check <files>` (Runic.jl), spelling: `typos src ext test docs`.
+- Tests: `GROUP=Core julia --project -e 'using Pkg; Pkg.test()'`; `GROUP=QA` for Aqua/ExplicitImports/JET; `GROUP=GPU` needs CUDA hardware. See `test/test_groups.toml`.
+- Docs: `julia --project=docs docs/make.jl` for any docstring or public-API change.
+
+## Temporary workarounds to remove
+
+### Static Padé products bypass StaticArrays' kernel on Julia 1.12
+
+The immutable-matrix `ExpMethodGeneric` path calls the hooks `_mul`, `_square` and `_horner`
+(src/exp_generic.jl), whose defaults are the original `*`, `^` and `Base.evalpoly`. The
+StaticArrays extension overrides them for non-float element types with a fully unrolled
+`muladd` chain per product entry. This works around a Julia 1.12 / LLVM 18 SLP
+vectorizer miscompile of StaticArrays' `mul_loop` that corrupts ForwardDiff partials, seen as
+`ForwardDiff.jacobian(exponential!, ::SMatrix{4,4,Float32})` being wrong on AVX-512 CI runners
+(the "exponential! on immutable (static) matrices" testset failing on about half of
+`Core (julia 1, ubuntu-latest)` runs from 2026-08-01).
+
+- Upstream: https://github.com/JuliaLang/julia/issues/62368, fixed in LLVM by
+  llvm/llvm-project@5d7cf504, awaiting a 1.12 backport.
+- Cost: the unrolled kernel is 1.7x (4×4 `Dual{Float32,16}`) to 4x (6×6 `Dual{Float64,36}`)
+  slower than StaticArrays' `*`; end to end the 4×4 Float64 Jacobian is about 1.4x slower and
+  the 6×6 about 2x. Plain-float matrices are unaffected and keep StaticArrays' kernel.
+- Remove when: the package's minimum supported Julia (`[compat] julia` in Project.toml) is a
+  release that contains the backport, i.e. the issue above is closed for 1.12.x or 1.12 is no
+  longer supported. To remove, delete the three overrides in the extension, inline the hook
+  defaults (`*`, `^`, `Base.evalpoly`) at their call sites in src/exp_generic.jl, and drop
+  `:_mul`, `:_square`, `:_horner` from the ExplicitImports ignore lists in test/qa/qa.jl.
+- To verify a Julia version is fixed without AVX-512 hardware, run the package-free reproducer
+  under Intel SDE Sapphire Rapids emulation, or natively with dense random partials:
+  a 4×4 `Dual{Nothing,Float32,16}` `SMatrix` product must match a Float64 reference to ~1e-7.
+  `JULIA_LLVM_ARGS="-vectorize-slp=false"` making a failure disappear confirms it is this bug.

--- a/ext/ExponentialUtilitiesStaticArraysExt.jl
+++ b/ext/ExponentialUtilitiesStaticArraysExt.jl
@@ -121,6 +121,22 @@ end
     end
 end
 
+# Julia 1.12 (LLVM 18) miscompiles StaticArrays' `mul_loop` product kernel at -O2 for
+# element types carrying 16-lane Float32 partials (ForwardDiff `Dual{T, Float32, 16}`),
+# corrupting the last partial of some entries. Forming each entry as an independent
+# `muladd` chain avoids the affected code shape.
+@generated function ExponentialUtilities._mul(a::SMatrix{M, K}, b::SMatrix{K, N}) where {M, K, N}
+    K == 0 && return :(a * b)
+    exprs = [
+        foldl(
+            (acc, j) -> :(muladd(a[$(k1 + (j - 1) * M)], b[$(j + (k2 - 1) * K)], $acc)), 2:K;
+            init = :(a[$k1] * b[$(1 + (k2 - 1) * K)])
+        )
+            for k1 in 1:M, k2 in 1:N
+    ]
+    return :(@inbounds SMatrix{$M, $N}(tuple($(exprs...))))
+end
+
 # exponential matrix-vector product for SArray types
 """
     expv(t::Number,A::SMatrix{N,N},v::SVector{N};kwarg...) → exp(t*A)*v

--- a/ext/ExponentialUtilitiesStaticArraysExt.jl
+++ b/ext/ExponentialUtilitiesStaticArraysExt.jl
@@ -121,12 +121,19 @@ end
     end
 end
 
-# Julia 1.12 (LLVM 18) miscompiles StaticArrays' `mul_loop` product kernel at -O2 for
-# element types carrying 16-lane Float32 partials (ForwardDiff `Dual{T, Float32, 16}`),
-# corrupting the last partial of some entries. Forming each entry as an independent
-# `muladd` chain avoids the affected code shape.
-@generated function ExponentialUtilities._mul(a::SMatrix{M, K}, b::SMatrix{K, N}) where {M, K, N}
-    K == 0 && return :(a * b)
+const IEEEFloat = Union{Float16, Float32, Float64}
+
+# TEMPORARY WORKAROUND for https://github.com/JuliaLang/julia/issues/62368: Julia 1.12
+# (LLVM 18) miscompiles StaticArrays' `mul_loop` kernel at -O2 for element types such as
+# ForwardDiff `Dual{T, Float32, 16}`, corrupting a partials lane of some entries. Plain
+# float matrices are unaffected and keep StaticArrays' kernel; other element types get a
+# fully unrolled `muladd` chain per entry, which is correct but 1.7x to 4x slower.
+# Remove these three methods (and the hooks in src/exp_generic.jl) once the minimum
+# supported Julia includes the LLVM backport of llvm/llvm-project@5d7cf504; see AGENTS.md.
+@generated function ExponentialUtilities._mul(
+        a::SMatrix{M, K, T}, b::SMatrix{K, N, T}
+    ) where {M, K, N, T}
+    (K == 0 || T <: IEEEFloat) && return :(a * b)
     exprs = [
         foldl(
             (acc, j) -> :(muladd(a[$(k1 + (j - 1) * M)], b[$(j + (k2 - 1) * K)], $acc)), 2:K;
@@ -135,6 +142,24 @@ end
             for k1 in 1:M, k2 in 1:N
     ]
     return :(@inbounds SMatrix{$M, $N}(tuple($(exprs...))))
+end
+
+function ExponentialUtilities._square(x::SMatrix{M, M, T}, s) where {M, T}
+    T <: IEEEFloat && return x^(2^s)
+    for _ in 1:s
+        x = ExponentialUtilities._mul(x, x)
+    end
+    return x
+end
+
+@generated function ExponentialUtilities._horner(x::SMatrix{M, M, T}, c::Tuple) where {M, T}
+    T <: IEEEFloat && return :(Base.evalpoly(x, c))
+    n = length(c.parameters)
+    ex = :(c[$n])
+    for i in (n - 1):-1:1
+        ex = :(ExponentialUtilities._mul(x, $ex) + c[$i])
+    end
+    return ex
 end
 
 # exponential matrix-vector product for SArray types

--- a/src/exp_generic.jl
+++ b/src/exp_generic.jl
@@ -182,22 +182,12 @@ function exponential!(
     end
 end
 
-# Every product on the immutable-matrix path goes through `_mul` so the StaticArrays
-# extension can substitute a kernel that Julia 1.12 does not miscompile (see there).
+# TEMPORARY hooks for the StaticArrays extension's Julia 1.12 miscompile workaround; the
+# defaults are exactly what the immutable-matrix path did before it. See the extension
+# and AGENTS.md for the removal condition.
 _mul(x, y) = x * y
-
-_square(x::Number, s) = x^(2^s)
-function _square(x, s)
-    for _ in 1:s
-        x = _mul(x, x)
-    end
-    return x
-end
-
-# `@evalpoly` with the products routed through `_mul`; `c[1]` is the constant term.
-@inline _horner(x, c::Tuple) = _horner(x, c[end], Base.front(c))
-@inline _horner(x, y, ::Tuple{}) = y
-@inline _horner(x, y, c::Tuple) = _horner(x, _mul(x, y) + c[end], Base.front(c))
+_square(x, s) = x^(2^s)
+_horner(x, c::Tuple) = Base.evalpoly(x, c)
 
 # Specialized (13,13) Padé numerator for the immutable-matrix path. The coefficient
 # type is taken from `eltype(x)` at runtime (rather than hardcoded `Float64`) so that a

--- a/src/exp_generic.jl
+++ b/src/exp_generic.jl
@@ -176,11 +176,28 @@ function exponential!(
     (Vk === Val{13}() && x isa AbstractMatrix && ismutable(x)) &&
         return exp_generic_mutable(x, s, Val{13}())
     if s >= 1
-        return exponential!(x / (2^s), method, cache)^(2^s)
+        return _square(exponential!(x / (2^s), method, cache), s)
     else
         return exp_pade_p(x, Vk, Vk) / exp_pade_q(x, Vk, Vk)
     end
 end
+
+# Every product on the immutable-matrix path goes through `_mul` so the StaticArrays
+# extension can substitute a kernel that Julia 1.12 does not miscompile (see there).
+_mul(x, y) = x * y
+
+_square(x::Number, s) = x^(2^s)
+function _square(x, s)
+    for _ in 1:s
+        x = _mul(x, x)
+    end
+    return x
+end
+
+# `@evalpoly` with the products routed through `_mul`; `c[1]` is the constant term.
+@inline _horner(x, c::Tuple) = _horner(x, c[end], Base.front(c))
+@inline _horner(x, y, ::Tuple{}) = y
+@inline _horner(x, y, c::Tuple) = _horner(x, _mul(x, y) + c[end], Base.front(c))
 
 # Specialized (13,13) Padé numerator for the immutable-matrix path. The coefficient
 # type is taken from `eltype(x)` at runtime (rather than hardcoded `Float64`) so that a
@@ -190,22 +207,24 @@ end
 # blocked, so ForwardDiff differentiation would fail.
 function exp_pade_p(x, ::Val{13}, ::Val{13})
     T = float(eltype(x))
-    return @evalpoly(
+    return _horner(
         x,
-        UniformScaling(T(1 // 1)),
-        UniformScaling(T(1 // 2)),
-        UniformScaling(T(3 // 25)),
-        UniformScaling(T(11 // 600)),
-        UniformScaling(T(11 // 5520)),
-        UniformScaling(T(3 // 18400)),
-        UniformScaling(T(1 // 96600)),
-        UniformScaling(T(1 // 1932000)),
-        UniformScaling(T(1 // 48944000)),
-        UniformScaling(T(1 // 1585785600)),
-        UniformScaling(T(1 // 67395888000)),
-        UniformScaling(T(1 // 3953892096000)),
-        UniformScaling(T(1 // 355850288640000)),
-        UniformScaling(T(1 // 64764752532480000))
+        (
+            UniformScaling(T(1 // 1)),
+            UniformScaling(T(1 // 2)),
+            UniformScaling(T(3 // 25)),
+            UniformScaling(T(11 // 600)),
+            UniformScaling(T(11 // 5520)),
+            UniformScaling(T(3 // 18400)),
+            UniformScaling(T(1 // 96600)),
+            UniformScaling(T(1 // 1932000)),
+            UniformScaling(T(1 // 48944000)),
+            UniformScaling(T(1 // 1585785600)),
+            UniformScaling(T(1 // 67395888000)),
+            UniformScaling(T(1 // 3953892096000)),
+            UniformScaling(T(1 // 355850288640000)),
+            UniformScaling(T(1 // 64764752532480000)),
+        )
     )
 end
 
@@ -289,7 +308,7 @@ end
         den = factorial(k + m) * factorial(k - j) * factorial(j)
         (float ∘ eltype)(x)(num // den) * (x <: Number ? 1 : I)
     end
-    return :(@evalpoly(x, $(p...)))
+    return x <: Number ? :(@evalpoly(x, $(p...))) : :(_horner(x, ($(p...),)))
 end
 
 exp_pade_q(x, k, m) = exp_pade_p(-x, m, k)

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -29,7 +29,7 @@ run_qa(
         # `_mul` is the package-internal product hook the StaticArrays extension
         # overrides.
         all_qualified_accesses_are_public = (;
-            ignore = (:arithmetic_closure, :promote_op, :_mul),
+            ignore = (:arithmetic_closure, :promote_op, :_mul, :_square, :_horner),
         ),
         # ArrayInterface.parameterless_type is not declared public but is the
         # standard way to adapt a host array to the GPU array type of `w`.
@@ -42,7 +42,7 @@ run_explicit_imports(
     Base.get_extension(ExponentialUtilities, :ExponentialUtilitiesStaticArraysExt), ExplicitImports;
     ei_kwargs = (;
         all_qualified_accesses_are_public = (;
-            ignore = (:arithmetic_closure, :_mul),
+            ignore = (:arithmetic_closure, :_mul, :_square, :_horner),
         ),
     ),
 )

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -26,8 +26,10 @@ run_qa(
         # an integer-valued `SMatrix`. It is documented -- its own docstring
         # demonstrates `import StaticArrays.arithmetic_closure` -- but StaticArrays
         # has not declared it `public`, and there is no public equivalent.
+        # `_mul` is the package-internal product hook the StaticArrays extension
+        # overrides.
         all_qualified_accesses_are_public = (;
-            ignore = (:arithmetic_closure, :promote_op),
+            ignore = (:arithmetic_closure, :promote_op, :_mul),
         ),
         # ArrayInterface.parameterless_type is not declared public but is the
         # standard way to adapt a host array to the GPU array type of `w`.
@@ -40,7 +42,7 @@ run_explicit_imports(
     Base.get_extension(ExponentialUtilities, :ExponentialUtilitiesStaticArraysExt), ExplicitImports;
     ei_kwargs = (;
         all_qualified_accesses_are_public = (;
-            ignore = (:arithmetic_closure,),
+            ignore = (:arithmetic_closure, :_mul),
         ),
     ),
 )


### PR DESCRIPTION
> **Ignore until reviewed by @ChrisRackauckas.**

Fixes the intermittent failure of the "exponential! on immutable (static) matrices" testset (`test/basictests.jl:134`) that has been failing about half of `Core (julia 1, ubuntu-latest)` jobs since 2026-08-01, e.g. https://github.com/SciML/ExponentialUtilities.jl/actions/runs/31863105429/job/94960882769 on master and https://github.com/SciML/ExponentialUtilities.jl/actions/runs/33956687857/job/101281395540 on #279.

## Root cause

Julia 1.12.7 (LLVM 18) at `-O2` miscompiles StaticArrays' `mul_loop` product kernel for `SMatrix{4,4,Dual{T,Float32,16}}`, the element type `ForwardDiff.jacobian(exponential!, ::SMatrix{4,4,Float32})` produces. This is the SLP-vectorizer bug tracked in https://github.com/JuliaLang/julia/issues/62368 (LLVM fix llvm/llvm-project@5d7cf504, awaiting a 1.12 backport); `JULIA_LLVM_ARGS="-vectorize-slp=false"` makes it disappear. Julia 1.10, 1.11, 1.13-rc, and 1.12 at `-O1` are unaffected. The unit-vector partials of a Jacobian only hit the bad lanes under AVX-512 codegen, which is why it appeared on 2026-08-01 with no relevant repo change (AVX-512 machines entered the GitHub runner pool), never fails on `lts`/`pre`/macOS, and never reproduces natively on AVX2 hosts. A package-free reproducer is posted on the upstream issue.

The wrong side is the static `exponential!` Jacobian, not the generic reference: the Jacobian of `exp` satisfies `J[(i,j),(k,l)] == J[(l,k),(j,i)]`, `Jref` satisfies it in every CI failure, and `J` violates it in the last column only.

Bisect (under Intel SDE Sapphire Rapids emulation): 09fdc25 (#237, adds the testset) passes 30/30; its child 1127963 (#238, keeps Float32 static Padé arithmetic in Float32 `Dual` instead of promoting to Float64) fails 22/30. That commit is the exposing change, not a bug in itself.

## Change (two commits)

1. The immutable-matrix `ExpMethodGeneric` path calls three package-private hooks, `_mul`, `_square`, `_horner`, whose defaults are exactly the original `*`, `^(2^s)`, and `Base.evalpoly`. The StaticArrays extension overrides them **only for non-float element types** (duals and the like) with a fully unrolled `muladd` chain per product entry, a code shape the vectorizer handles correctly. Plain `Float16/32/64` matrices keep StaticArrays' kernel and master's exact code path.
2. The workaround is documented as temporary in the code comments and in a new `AGENTS.md` with the upstream link, the measured cost, the removal condition, and how to verify a Julia release is fixed.

## Performance

**This is a slowdown on the AD path, not a speedup.** Julia 1.12.7, single thread, Zen 2, `@belapsed` medians; master is d2aad59, PR is 6a0b015:

| case | `exponential!` master | PR | `ForwardDiff.jacobian` master | PR |
|---|---|---|---|---|
| `SMatrix{3,3,Float64}` | 0.38 µs | 0.37 µs | 4.85 µs | 4.82 µs |
| `SMatrix{4,4,Float64}` | 0.90 µs | 0.87 µs | 14.6 µs | 20.8 µs |
| `SMatrix{3,3,Float32}` | 0.36 µs | 0.36 µs | 4.70 µs | 4.93 µs |
| `SMatrix{4,4,Float32}` | 0.76 µs | 0.77 µs | 13.9 µs | 16.7 µs |
| `SMatrix{6,6,Float64}` | 1.92 µs | 1.86 µs | 164 µs | 328 µs |

Product kernel alone, 4×4 `Dual{Float32,16}`: StaticArrays `*` 304 ns (and **wrong** on dense partials natively), unrolled `muladd` chain 549 ns. Every safe shape tried (plain `+` chain, interleaved `mul_loop` order fully unrolled, column broadcast, StaticArrays' `*` compiled at `-O1` in a `@noinline` module) costs the same or more; the loop-carried `ntuple` forms were 100× slower. The speed of `mul_loop` comes from SLP packing across the 16 accumulators, which is exactly what miscompiles. Zero allocations everywhere.

## Verification

Failing before / passing after, unmodified master vs this branch, Julia 1.12.7 under `sde64 -spr`, `(n=4, T=Float32)`, seeds 1 to 10:

```
== d2aad59 (master)
(n=4, T=Float32): 6/10 failures   seed=1 maxrelerr=2.0e-3  seed=2 4.5e-3  seed=4 1.6e-3  seed=5 1.2e-3  seed=7 2.6e-3   (rtol = 3.45e-4)
== 6a0b015 (this PR, final head)
(n=4, T=Float32): 0/10 failures   TOTAL: 0 / 40 across all four (n, T)
```

Larger sweeps on the first commit's kernel (same generated code): 0/240 across all four `(n, T)` combos on emulated Sapphire Rapids and Ice Lake; 0/400 on emulated Granite Rapids (master: 74/100). Native 2000-seed sweep: 0/8000.

Local test runs on 6a0b015 (Julia 1.12.7):

```
GROUP=Core   Core/basictests.jl |  742       1    743  4m12.8s   (exit 0)
GROUP=QA     QA/qa.jl           |   27   1    2     30  3m07.9s   (identical to master; the error is the `eigen` implicit import from #278, fixed by #279)
Runic --check  clean
typos          clean
```

CI on the previous head 88bd0d6: 34 pass, 1 fail (that same QA error); the full Core matrix including both Julia 1 jobs that had been flaking was green.

**Not verified:** real AVX-512 hardware (only SDE emulation), downstream, `julia pre` locally.

**Reviewer attention:** this is a workaround for a compiler bug and slows the ForwardDiff path through static matrices by 1.2× to 2× depending on size. The alternative is to leave master as is and accept ~50% red `Core (julia 1)` jobs until a 1.12.x with the LLVM backport ships. `AGENTS.md` records how to remove it.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Code 2.1.261, model: claude-fable-5-1)

https://claude.ai/code/session_01LoGUEUrLDsXQjfRRTvYdya
