### PR TITLE
Release ExponentialUtilities 1.35.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ExponentialUtilities"
 uuid = "d4d017d3-3776-5f7e-afef-a10c40355c18"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "José E. Cruz Serrallés <Jose.CruzSerralles@nyulangone.org>"]
-version = "1.35.1"
+version = "1.35.2"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"


### PR DESCRIPTION
Bumps `ExponentialUtilities` 1.35.1 -> 1.35.2 (patch).

Source files changed since 1.35.1:
- `ext/ExponentialUtilitiesStaticArraysExt.jl`
- `src/exp_generic.jl`
- `src/krylov_phiv_error_estimate.jl`

Commits:
- Drop stale [compat] majors older than one year (#274)
- compat: drop the unregistered SafeTestsets 1.x major (#275)
- Use non-mutating `eigen` in `expT!` to avoid corrupting the Lanczos diagonal (#278)
- Work around Julia 1.12 miscompile of static Padé products (#280)

Version bump only; no code changes in this PR.


🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m])

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R
