### PR TITLE
Keep the input array type in error-estimate `expv`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -30,6 +30,7 @@ DoubleFloats = "1.1.14"
 ForwardDiff = "1"
 GPUArraysCore = "0.1, 0.2"
 GenericSchur = "0.5.3"
+JLArrays = "0.3"
 LinearAlgebra = "1.10"
 LinearSolve = "5"
 PrecompileTools = "1.2.1"
@@ -48,6 +49,7 @@ julia = "1.10"
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 DoubleFloats = "497a8b3b-efae-58df-a0af-a86822472b78"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+JLArrays = "27aeb0d3-9eb9-45fb-866b-73c2ecf80fcb"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
@@ -55,4 +57,4 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "DoubleFloats", "ForwardDiff", "Test", "SafeTestsets", "SciMLTesting", "StaticArrays", "Random"]
+test = ["Aqua", "DoubleFloats", "ForwardDiff", "JLArrays", "Test", "SafeTestsets", "SciMLTesting", "StaticArrays", "Random"]

--- a/src/arnoldi.jl
+++ b/src/arnoldi.jl
@@ -75,6 +75,19 @@ end
 KrylovSubspace{T}(args...) where {T} = KrylovSubspace{T, T}(args...)
 KrylovSubspace{T, U}(args...) where {T, U} = KrylovSubspace{T, U, Matrix{T}}(args...)
 
+# Build a subspace whose basis matches the storage of `prototype`, so a device-backed
+# input keeps its array type instead of silently falling back to a host `Matrix`.
+function _krylov_subspace(
+        prototype::AbstractArray, ::Type{T}, ::Type{U},
+        n::Integer, maxiter::Integer, augmented::Integer = false
+    ) where {T, U}
+    V = similar(prototype, T, (n + augmented, maxiter + 1))
+    H = fill(zero(U), maxiter + 1, maxiter + !iszero(augmented))
+    return KrylovSubspace{T, U, real(T), typeof(V), Matrix{U}}(
+        maxiter, maxiter, augmented, zero(real(T)), false, V, H
+    )
+end
+
 getV(Ks::KrylovSubspace) = @view(Ks.V[:, 1:(Ks.m + 1)])
 getH(Ks::KrylovSubspace) = @view(Ks.H[1:(Ks.m + 1), 1:(Ks.m + !iszero(Ks.augmented))])
 function Base.resize!(Ks::KrylovSubspace{T, U}, maxiter::Integer) where {T, U}

--- a/src/krylov_phiv.jl
+++ b/src/krylov_phiv.jl
@@ -151,7 +151,7 @@ function _expv_ee(
     n = size(A, 1)
     T = promote_type(typeof(t), eltype(A), eltype(b))
     U = ishermitian ? real(T) : T
-    Ks = KrylovSubspace{T, U}(n, m)
+    Ks = _krylov_subspace(b, T, U, n, m)
     w = similar(b, promote_type(Tt, eltype(A), eltype(b)))
     return expv!(
         w, t, A, b, Ks, get_subspace_cache(Ks); atol = tol, rtol = rtol,

--- a/test/basictests.jl
+++ b/test/basictests.jl
@@ -3,6 +3,7 @@ using ExponentialUtilities: getH, getV, exponential!, ExpMethodNative,
     ExpMethodDiagonalization, ExpMethodHigham2005, ExpMethodGeneric,
     ExpMethodHigham2005Base, alloc_mem
 using ForwardDiff, StaticArrays, DoubleFloats
+using JLArrays
 
 @testset "alloc_mem public API" begin
     A = [1.0 0.0; 0.0 1.0]
@@ -846,6 +847,30 @@ end
         α, β, _ = tridiag_case(R, n)
         @test alloc_expT(α, β, t, cache) == 0
     end
+end
+
+@testset "expv error-estimate mode preserves the input array type" begin
+    # JLArrays is the reference GPUArrays backend and disallows scalar indexing, so a
+    # host-backed Krylov basis makes these calls throw rather than silently work.
+    Random.seed!(11)
+    n = 120
+    A = Matrix(Hermitian(rand(n, n))) ./ 10
+    b = rand(ComplexF64, n)
+    kw = (m = 30, tol = 1.0e-10, rtol = 1.0e-10, mode = :error_estimate)
+    wref = expv(-im, A, b; kw...)
+
+    w = expv(-im, JLArray(A), JLArray(b); kw...)
+    @test w isa JLArray
+    @test Array(w) ≈ wref rtol = 1.0e-10
+
+    # the in-place entry point with an explicitly device-resident subspace
+    Ks = KrylovSubspace{ComplexF64, Float64, JLArray{ComplexF64, 2}}(n, 30)
+    wd = JLArray(similar(b))
+    expv!(
+        wd, -im, JLArray(A), JLArray(b), Ks, get_subspace_cache(Ks);
+        atol = 1.0e-10, rtol = 1.0e-10, ishermitian = true
+    )
+    @test Array(wd) ≈ wref rtol = 1.0e-10
 end
 
 module ExternalMatrixFreeOperator


### PR DESCRIPTION
> **Ignore until reviewed by @ChrisRackauckas.**

`expv(t, A, b; mode = :error_estimate)` has never worked on a device-backed `b`. `_expv_ee` builds its Krylov basis with `KrylovSubspace{T, U}(n, m)`, which resolves to `KrylovSubspace{T, U, Matrix{T}}` and always allocates a host `Matrix`, so the first line of the error-estimate `expv!` that broadcasts `b` into the basis (`@. V[:, 1] = b / Ks.beta`) scalar-indexes the device array. The default happy-breakdown path is unaffected, because `arnoldi` derives its basis from `similar(b, T, ...)`.

A private `_krylov_subspace(prototype, T, U, n, maxiter, augmented)` helper now builds the subspace from the input the same way `arnoldi` does, and `_expv_ee` uses it. The Hessenberg coefficients stay a host `Matrix`, which is what the error estimate and the subspace exponential need; only the basis follows the input storage.

No public API change: the helper is private, the `KrylovSubspace` constructors are untouched, and host behaviour is bit-identical.

## Verification

Failing before / passing after, same script, Julia 1.12.7, `JLArray` input (JLArrays disallows scalar indexing by default, so this is a hard failure rather than a slow fallback):

```
--- WITHOUT fix (master 88b0312):
RESULT: FAIL  Scalar indexing is disallowed. Invocation of getindex r
--- WITH fix:
RESULT: PASS  w isa JLArray = true  rel.err = 1.01e-15
```

The new testset in `test/basictests.jl` is that same check plus the in-place entry point with an explicitly device-resident subspace, which already worked and must keep working. `JLArrays` is added to `[extras]`/`[targets]` with a `[compat]` bound; it is MIT, same as this package, and is the reference GPUArrays backend, so the test runs on ordinary CI machines without GPU hardware.

Local runs (Julia 1.12.7):

```
GROUP=Core   Core/basictests.jl |  855       1    856  4m35.0s   (exit 0; 852 -> 855 is the three new tests)
GROUP=QA     QA/qa.jl           |   28       2     30  3m06.7s   (exit 0)
julia --project=docs docs/make.jl                                (exit 0, no errors)
Runic --check / typos                                            clean
```

Aqua's `deps_compat` rejected the new test dependency until it had a `[compat]` entry; that is included.

**Not verified:** real CUDA hardware (JLArrays only), the GPU test group, downstream, `julia pre` locally, and the 32-bit lane. JLArrays is pure Julia so the 32-bit lane should be fine, but CI is the check.

**Reviewer attention, two things.**

1. This adds a test dependency. If you would rather not carry `JLArrays` in `[extras]`, the alternative is to move the test into `test/gpu/gputests.jl` behind CUDA, where it would only run on the self-hosted GPU runner and would not have caught this bug in the first place.
2. `kiops` has the same root cause and is **not** fixed here. `kiops(tau_out, A, u)` on a device `u` also fails, and swapping in `_krylov_subspace` is necessary but not sufficient: its `w = zeros(n, numSteps)` and `w_aug = zeros(p)` work arrays are host-allocated too (`src/kiops.jl:89-90`), and it still throws at line 91. I reverted that part rather than ship a change with no test that discriminates. Happy to do `kiops` as a follow-up if you want it. `expv_timestep` on device arrays works today and is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoGUEUrLDsXQjfRRTvYdya
