### PR TITLE
Release ExponentialUtilities 1.35.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ExponentialUtilities"
 uuid = "d4d017d3-3776-5f7e-afef-a10c40355c18"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>", "José E. Cruz Serrallés <Jose.CruzSerralles@nyulangone.org>"]
-version = "1.35.2"
+version = "1.35.3"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"


### PR DESCRIPTION
Bumps `ExponentialUtilities` 1.35.2 -> 1.35.3 (patch).

Source files changed since 1.35.2:
- `ext/ExponentialUtilitiesStaticArraysExt.jl`
- `src/arnoldi.jl`
- `src/krylov_phiv.jl`
- `src/krylov_phiv_error_estimate.jl`

Commits:
- Add 32-bit Core CI lane via test_groups.toml (#282)
- Diagonalize the Lanczos subspace matrix without allocating (#279)
- Keep the input array type in error-estimate expv (#283)

Version bump only; no code changes in this PR.


🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m])

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R
