### PR TITLE
Add AirspeedVelocity benchmarking CI

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,29 @@
+name: Benchmark this PR
+
+on:
+  pull_request:
+    branches: [master]
+    paths-ignore: ['docs/**']
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ["1", "lts"]
+    env:
+      # Force consistent Julia depot path for self-hosted runners
+      JULIA_DEPOT_PATH: ~/.julia
+    steps:
+      - uses: MilesCranmer/AirspeedVelocity.jl@action-v1
+        with:
+          julia-version: ${{ matrix.version }}
+          script: "benchmark/benchmarks.jl"
+          extra-pkgs: "StableRNGs"
+          job-summary: true

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,0 +1,47 @@
+using ExponentialUtilities, BenchmarkTools
+using LinearAlgebra, SparseArrays, StableRNGs
+
+const SUITE = BenchmarkGroup()
+const rng = StableRNG(123)
+
+N = 100
+A = rand(rng, N, N)
+b = rand(rng, N)
+As = sprand(rng, 500, 500, 0.01)
+bs = rand(rng, 500)
+
+# =============================================================================
+# Dense matrix exponential
+# =============================================================================
+
+SUITE["expm"] = BenchmarkGroup()
+
+SUITE["expm"]["dense"] = @benchmarkable exponential!(A) setup = (A = copy($A))
+SUITE["expm"]["higham2005"] = @benchmarkable exponential!(
+    A, ExpMethodHigham2005()
+) setup = (A = copy($A))
+SUITE["expm"]["alloc_mem"] = @benchmarkable ExponentialUtilities.alloc_mem(
+    $A, ExpMethodHigham2005()
+)
+
+# =============================================================================
+# Krylov subspace methods
+# =============================================================================
+
+SUITE["krylov"] = BenchmarkGroup()
+
+SUITE["krylov"]["arnoldi"] = @benchmarkable arnoldi($As, $bs)
+SUITE["krylov"]["expv_dense"] = @benchmarkable expv(0.5, $A, $b)
+SUITE["krylov"]["expv_sparse"] = @benchmarkable expv(0.5, $As, $bs)
+SUITE["krylov"]["expv_timestep"] = @benchmarkable expv_timestep(
+    0.5, $As, $bs; adaptive = true
+)
+
+# =============================================================================
+# phi functions
+# =============================================================================
+
+SUITE["phi"] = BenchmarkGroup()
+
+SUITE["phi"]["phiv"] = @benchmarkable phiv(0.5, $As, $bs, 3)
+SUITE["phi"]["phi_dense"] = @benchmarkable phi($(A * 0.1), 3)


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/benchmark.yml` running AirspeedVelocity on pull requests (Julia `1` and `lts`, 30 min timeout), following the OrdinaryDiffEq.jl setup.
- Adds `benchmark/benchmarks.jl` with a small `SUITE` covering representative workloads for this package.

The suite was verified locally in a fresh environment: it loads and all benchmarks run in ~51s.

#### Test plan

- [x] `run(SUITE)` locally: all benchmarks pass (~51s)
- [x] Runic formatting clean on `benchmark/benchmarks.jl`
- [ ] \"Benchmark this PR\" workflow triggers and completes on this PR

🤖 Generated with [Devin](https://devin.ai) (harness: devin 3000.10.21, model: SWE-2 High)
Session: local transcript /home/crackauc/sandbox/tmp_20260911_112052_59120/history_6a789c0b69c64ca3.md